### PR TITLE
Build USI with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: scala
+scala:
+   - 2.12.2
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Summary:
This enables pull request builds with Travis CI. I propose to start with
Travis for the following reasons:
  * Travis uses VMs only once. No left over from previous builds can
    disturb the next builds.
  * We won't exceed Github API quota.
  * Builds are cached.
  * VMs are managed.
  * The door to migrate to another CI solution is not closed.