### PR TITLE
Added a docs folder and a sample index page.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Unified Scheduler Interface
+
+This repository is currently a work-in-progress.
+
+
+How to run:
+
+```
+$ gradle :hello-world:run
+```
+
+
+How to test:
+
+```
+$ gradle test
+```


### PR DESCRIPTION
In Github there is a feature for automatic docs generation based on `/docs` folder in master.:
![image](https://user-images.githubusercontent.com/1043441/51686173-28e1a780-1ff0-11e9-9ba0-2cec24f6c283.png)

Let's try it out.

JIRA issues: DCOS-47511