### PR TITLE
Publish Scaladoc to Github pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: scala
 scala:
    - 2.12.2
+script:
+  - ./gradlew ci
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-after_script:
-  - if [[ ! -z "$GIT_PASSWORD" ]]; then ./gradlew githubReport; fi
-  - if [[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]]; then ./gradlew gitPublishPush; fi
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 after_script:
-  - 'if [[ ! -z "$GIT_PASSWORD" ]]; then ./gradlew githubReport; fi'
+  - if [[ ! -z "$GIT_PASSWORD" ]]; then ./gradlew githubReport; fi
+  - if [[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]]; then ./gradlew gitPublishPush; fi
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 import mesosphere.gradle.aws.S3Upload
 import mesosphere.gradle.github.GithubStatus
 
+plugins {
+    id 'org.ajoberstar.git-publish' version '2.0.0'
+}
+
 subprojects {
     version = '1.0'
     apply plugin: "scala"
@@ -56,3 +60,21 @@ task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
     statusDescription = "Test results"
     targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/index.html"
 }
+
+gitPublish {
+    repoUri = 'git@github.com:mesosphere/usi.git'
+    branch = 'gh-pages'
+
+    contents {
+        subprojects.each { subproject ->
+            subproject.tasks.withType(ScalaDoc).each { sdoc ->
+               from sdoc.destinationDir into subproject.name
+            }
+        }
+    }
+
+    preserve {
+        include 'index.html'
+    }
+}
+gitPublishCopy.dependsOn(subprojects*.scaladoc)

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,20 @@ subprojects {
     test {
         reports.html.enabled = false
     }
-
-    scaladoc {
-        destinationDir file(Paths.get(rootProject.buildDir.toString(), "gitPublish", project.name))
-    }
 }
 
-task aggregateScalaDoc(type: ScalaDoc) {
-    source += subprojects*.sourceSets.main.allScala
+task scaladoc(type: ScalaDoc) {
+    description = "Builds all Scala docs into the gh-pages checkout for publishing."
+    destinationDir file(Paths.get(rootProject.buildDir.toString(), "gitPublish", "api"))
+
+    source = files(subprojects.collect{it.sourceSets.main.allScala + it.sourceSets.main.allJava})
+    classpath = files(subprojects.collect {it.sourceSets.main.compileClasspath})
+    scalaClasspath = subprojects.first().scaladoc.scalaClasspath
+
+    subprojects.each {
+        excludes += it.scaladoc.excludes
+        includes += it.scaladoc.includes
+    }
 }
 
 task testReport(type: TestReport) {
@@ -75,8 +81,14 @@ gitPublish {
     repoUri = 'git@github.com:mesosphere/usi.git'
     branch = 'gh-pages'
 
+    contents {
+        from "docs"
+    }
+
     preserve {
-        include 'index.html'
+        // Preserve all files from /docs on master.
+        include '_config.yml'
+        include '**/*.md'
     }
 }
-gitPublishCopy.dependsOn(subprojects*.scaladoc)
+gitPublishCopy.dependsOn(scaladoc)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import mesosphere.gradle.aws.S3Upload
 import mesosphere.gradle.github.GithubStatus
 
+import java.nio.file.Paths
+
 plugins {
     id 'org.ajoberstar.git-publish' version '2.0.0'
 }
@@ -28,6 +30,14 @@ subprojects {
     test {
         reports.html.enabled = false
     }
+
+    scaladoc {
+        destinationDir file(Paths.get(rootProject.buildDir.toString(), "gitPublish", project.name))
+    }
+}
+
+task aggregateScalaDoc(type: ScalaDoc) {
+    source += subprojects*.sourceSets.main.allScala
 }
 
 task testReport(type: TestReport) {
@@ -64,14 +74,6 @@ task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
 gitPublish {
     repoUri = 'git@github.com:mesosphere/usi.git'
     branch = 'gh-pages'
-
-    contents {
-        subprojects.each { subproject ->
-            subproject.tasks.withType(ScalaDoc).each { sdoc ->
-               from sdoc.destinationDir into subproject.name
-            }
-        }
-    }
 
     preserve {
         include 'index.html'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-import mesosphere.gradle.aws.S3Upload
-import mesosphere.gradle.github.GithubStatus
-import mesosphere.gradle.travis.TravisEnvironment
 
 import java.nio.file.Paths
 
@@ -41,6 +38,8 @@ allprojects {
     check {}
 }
 
+apply from: 'ci.gradle'
+
 scaladoc {
     description = "Builds all Scala docs into the gh-pages checkout for publishing."
     destinationDir file(Paths.get(rootProject.buildDir.toString(), "gitPublish", "api"))
@@ -61,63 +60,4 @@ idea {
     languageLevel = '1.8'
     vcs = 'Git'
   }
-}
-
-task testReport(type: TestReport) {
-    description = "Aggregate all test results from subprojects into one test report."
-
-    destinationDir = file("$buildDir/reports/allTests")
-    // Include the results from the `test` task in all subprojects
-    reportOn subprojects*.test
-    dependsOn(subprojects.check)
-}
-
-task uploadTestReports(type: S3Upload, dependsOn: testReport) {
-    description = "Upload Gradle test reports to S3."
-    dependsOn testReport
-    
-    String repoSlug = TravisEnvironment.repoSlug()
-    String branch = TravisEnvironment.branch()
-    String buildNumber = TravisEnvironment.buildNumber()
-    
-    region = "us-west-2"
-    bucket = "usi-builds"
-    prefix = "$repoSlug/$branch/$buildNumber"
-    source = testReport.destinationDir
-}
-
-task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
-    description = "Report test results to Github as commit status."
-    dependsOn uploadTestReports
-    
-    repoSlug = TravisEnvironment.repoSlug()
-    commit = TravisEnvironment.commit()
-    context = "mesosphere/tests"
-    statusDescription = "Test results"
-    targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/index.html"
-}
-
-gitPublish {
-    repoUri = 'git@github.com:mesosphere/usi.git'
-    branch = 'gh-pages'
-
-    contents {
-        from "docs"
-    }
-
-    preserve {
-        // Preserve all files from /docs on master.
-        include '_config.yml'
-        include '**/*.md'
-    }
-}
-gitPublishCopy.dependsOn(scaladoc)
-
-task ci {
-    description = "The main traget for CI builds."
-    if (TravisEnvironment.isMasterBuild()) {
-        dependsOn githubReport, gitPublishPush
-    } else if (TravisEnvironment.isSecureBuild())  {
-        dependsOn githubReport
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import mesosphere.gradle.aws.S3Upload
 import mesosphere.gradle.github.GithubStatus
+import mesosphere.gradle.travis.TravisEnvironment
 
 import java.nio.file.Paths
 
@@ -30,6 +31,7 @@ subprojects {
     test {
         reports.html.enabled = false
     }
+    check {}
 }
 
 task scaladoc(type: ScalaDoc) {
@@ -52,14 +54,16 @@ task testReport(type: TestReport) {
     destinationDir = file("$buildDir/reports/allTests")
     // Include the results from the `test` task in all subprojects
     reportOn subprojects*.test
+    dependsOn(subprojects.check)
 }
 
 task uploadTestReports(type: S3Upload, dependsOn: testReport) {
     description = "Upload Gradle test reports to S3."
+    dependsOn testReport
     
-    String repoSlug = System.getenv().get("TRAVIS_REPO_SLUG")
-    String branch = System.getenv().get("TRAVIS_PULL_REQUEST_BRANCH") ?: System.getenv().get("TRAVIS_BRANCH")
-    String buildNumber = System.getenv().get("TRAVIS_BUILD_NUMBER")
+    String repoSlug = TravisEnvironment.repoSlug()
+    String branch = TravisEnvironment.branch()
+    String buildNumber = TravisEnvironment.buildNumber()
     
     region = "us-west-2"
     bucket = "usi-builds"
@@ -69,9 +73,10 @@ task uploadTestReports(type: S3Upload, dependsOn: testReport) {
 
 task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
     description = "Report test results to Github as commit status."
+    dependsOn uploadTestReports
     
-    repoSlug = System.getenv().get("TRAVIS_REPO_SLUG")
-    commit = System.getenv().get("TRAVIS_COMMIT")
+    repoSlug = TravisEnvironment.repoSlug()
+    commit = TravisEnvironment.commit()
     context = "mesosphere/tests"
     statusDescription = "Test results"
     targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/index.html"
@@ -92,3 +97,12 @@ gitPublish {
     }
 }
 gitPublishCopy.dependsOn(scaladoc)
+
+task ci {
+    description = "The main traget for CI builds."
+    if (TravisEnvironment.isMasterBuild()) {
+        dependsOn githubReport, gitPublishPush
+    } else if (TravisEnvironment.isSecureBuild())  {
+        dependsOn githubReport
+    }
+}

--- a/buildSrc/src/main/scala/mesosphere/gradle/travis/TravisEnvironment.scala
+++ b/buildSrc/src/main/scala/mesosphere/gradle/travis/TravisEnvironment.scala
@@ -1,0 +1,51 @@
+package mesosphere.gradle.travis
+
+import scala.util.Properties
+
+/**
+  * Exposes the Travis CI build environment according to o
+  *
+  * @see [[https://docs.travis-ci.com/user/environment-variables/#default-environment-variables]]
+  */
+object TravisEnvironment {
+
+  /**
+    * @return the repo slug, eg mesosphere/usi, of this build.
+    */
+  def repoSlug(): String = Properties.envOrElse("TRAVIS_REPO_SLUG", "unknown")
+
+  /*
+   * @return the name of the branch that is build.
+   */
+  def branch(): String = {
+    if (isPullRequestBuild()) sys.env("TRAVIS_PULL_REQUEST_BRANCH")
+    else Properties.envOrElse("TRAVIS_BRANCH", "unknown")
+  }
+
+  /**
+    * @return the commit SHA of this build.
+    */
+  def commit(): String = Properties.envOrElse("TRAVIS_COMMIT", "unknown")
+
+  /**
+    * @return the number of the build.
+    */
+  def buildNumber(): String = Properties.envOrElse("TRAVIS_BUILD_NUMBER", "unknown")
+
+  /**
+    * @return true if this is a build of a pull request.
+    */
+  def isPullRequestBuild(): Boolean = Properties.envOrElse("TRAVIS_PULL_REQUEST", "false") != "false"
+
+  /**
+    * @return true if this is a build of the master branch.
+    */
+  def isMasterBuild(): Boolean = !isPullRequestBuild() && branch() == "master"
+
+  /**
+    * For Travis CI this build means that it's not a build of a fork. Thus credentials are exposed in variables.
+    *
+    * @return true if the build is for trusted source.
+    */
+  def isSecureBuild(): Boolean = Properties.envOrElse("TRAVIS_SECURE_ENV_VARS", "false") == "true"
+}

--- a/ci.gradle
+++ b/ci.gradle
@@ -1,0 +1,63 @@
+import mesosphere.gradle.aws.S3Upload
+import mesosphere.gradle.github.GithubStatus
+import mesosphere.gradle.travis.TravisEnvironment
+
+
+task testReport(type: TestReport) {
+    description = "Aggregate all test results from subprojects into one test report."
+
+    destinationDir = file("$buildDir/reports/allTests")
+    // Include the results from the `test` task in all subprojects
+    reportOn subprojects*.test
+    dependsOn(subprojects.check)
+}
+
+task uploadTestReports(type: S3Upload, dependsOn: testReport) {
+    description = "Upload Gradle test reports to S3."
+    dependsOn testReport
+
+    String repoSlug = TravisEnvironment.repoSlug()
+    String branch = TravisEnvironment.branch()
+    String buildNumber = TravisEnvironment.buildNumber()
+
+    region = "us-west-2"
+    bucket = "usi-builds"
+    prefix = "$repoSlug/$branch/$buildNumber"
+    source = testReport.destinationDir
+}
+
+task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
+    description = "Report test results to Github as commit status."
+    dependsOn uploadTestReports
+
+    repoSlug = TravisEnvironment.repoSlug()
+    commit = TravisEnvironment.commit()
+    context = "mesosphere/tests"
+    statusDescription = "Test results"
+    targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/index.html"
+}
+
+gitPublish {
+    repoUri = 'git@github.com:mesosphere/usi.git'
+    branch = 'gh-pages'
+
+    contents {
+        from "docs"
+    }
+
+    preserve {
+        // Preserve all files from /docs on master.
+        include '_config.yml'
+        include '**/*.md'
+    }
+}
+gitPublishCopy.dependsOn(scaladoc)
+
+task ci {
+    description = "The main target for CI builds."
+    if (TravisEnvironment.isMasterBuild()) {
+        dependsOn githubReport, gitPublishPush
+    } else if (TravisEnvironment.isSecureBuild())  {
+        dependsOn githubReport
+    }
+}

--- a/ci.gradle
+++ b/ci.gradle
@@ -5,6 +5,7 @@ import mesosphere.gradle.travis.TravisEnvironment
 
 task testReport(type: TestReport) {
     description = "Aggregate all test results from subprojects into one test report."
+    group = "CI"
 
     destinationDir = file("$buildDir/reports/allTests")
     // Include the results from the `test` task in all subprojects
@@ -12,8 +13,9 @@ task testReport(type: TestReport) {
     dependsOn(subprojects.check)
 }
 
-task uploadTestReports(type: S3Upload, dependsOn: testReport) {
+task uploadTestReports(type: S3Upload) {
     description = "Upload Gradle test reports to S3."
+    group = "CI"
     dependsOn testReport
 
     String repoSlug = TravisEnvironment.repoSlug()
@@ -26,8 +28,9 @@ task uploadTestReports(type: S3Upload, dependsOn: testReport) {
     source = testReport.destinationDir
 }
 
-task githubReport(type: GithubStatus, dependsOn: uploadTestReports) {
+task githubReport(type: GithubStatus) {
     description = "Report test results to Github as commit status."
+    group = "CI"
     dependsOn uploadTestReports
 
     repoSlug = TravisEnvironment.repoSlug()
@@ -55,6 +58,7 @@ gitPublishCopy.dependsOn(scaladoc)
 
 task ci {
     description = "The main target for CI builds."
+    group = "CI"
     if (TravisEnvironment.isMasterBuild()) {
         dependsOn githubReport, gitPublishPush
     } else if (TravisEnvironment.isSecureBuild())  {

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 This repository is currently a work-in-progress.
 
+[Scaladoc](api/index.html)
+
 
 How to run:
 

--- a/examples/hello-world/src/main/scala/com/mesosphere/usi/helloworld/Main.scala
+++ b/examples/hello-world/src/main/scala/com/mesosphere/usi/helloworld/Main.scala
@@ -6,6 +6,9 @@ import com.mesosphere.usi.interface.PodSpec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+/**
+  * A demonstration of USI features.
+  */
 object Main extends App {
 
   val scheduler =  new Scheduler

--- a/interfaces/src/main/scala/com/mesosphere/usi/interface/DummySchedulerInterface.scala
+++ b/interfaces/src/main/scala/com/mesosphere/usi/interface/DummySchedulerInterface.scala
@@ -12,6 +12,9 @@ object DummySchedulerInterface {
   type DeploymentId = String
 }
 
+/**
+  * The pod sec describes a Mesos task group that should be launched.
+  */
 trait PodSpec {
   def id: String
   def goal: String


### PR DESCRIPTION
Summary:
This will aggregate all Scala documentations into one under the `api` folder on the
`gh-pages` branch. It will also copy all content from `./docs` to the `gh-pages`.