### PR TITLE
Add `metrics` and `metrics-dropwizard` modules to the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,15 +26,25 @@ allprojects {
     }
 
     dependencies {
+        // Scala version for all scala dependencies
+        def scalaVersion = '2.12'
+
         // Use Scala 2.12 in our library project
         implementation 'org.scala-lang:scala-library:2.12.7'
 
         // Use Scalatest for testing our library
-        testImplementation 'junit:junit:4.12'
-        testImplementation 'org.scalatest:scalatest_2.12:3.0.5'
+        testImplementation "junit:junit:4.12"
+        testImplementation "org.scalatest:scalatest_$scalaVersion:3.0.5"
 
         // Need scala-xml at test runtime
-        testRuntimeOnly 'org.scala-lang.modules:scala-xml_2.12:1.1.1'
+        testRuntimeOnly "org.scala-lang.modules:scala-xml_$scalaVersion:1.1.1"
+
+        // Logging
+        compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+        compile group: 'com.typesafe.scala-logging', name: "scala-logging_$scalaVersion", version: '3.9.2'
+
+        // Akka
+        compile group: 'com.typesafe.akka', name: "akka-http_$scalaVersion", version: '10.0.11'
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ allprojects {
     version = '0.1'
     apply plugin: "scala"
 
+    sourceCompatibility = 1.8
     targetCompatibility = 1.8
     compileScala.targetCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
         implementation 'org.scala-lang:scala-library:2.12.7'
 
         // Use Scalatest for testing our library
-        testImplementation "junit:junit:4.12"
+        testImplementation 'junit:junit:4.12'
         testImplementation "org.scalatest:scalatest_$scalaVersion:3.0.5"
 
         // Need scala-xml at test runtime

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ allprojects {
         testRuntimeOnly "org.scala-lang.modules:scala-xml_$scalaVersion:1.1.1"
 
         // Logging
-        compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
         compile group: 'com.typesafe.scala-logging', name: "scala-logging_$scalaVersion", version: '3.9.2'
 
         // Akka

--- a/metrics-dropwizard/README.md
+++ b/metrics-dropwizard/README.md
@@ -1,0 +1,140 @@
+# Metrics
+
+This is a [Dropwizard Metrics](https://github.com/dropwizard/metrics) implementation 
+of the USI metrics interface. It supports multiple exporters ([DataDog(https://www.datadoghq.com/)],
+[StatsD](https://github.com/etsy/statsd)) as well as text representation in 
+[Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) format.
+
+Histograms and timers are backed with reservoirs leveraging
+[HdrHistogram](http://hdrhistogram.org/).
+
+## Metric names
+
+All metric names are prefixed with `usi` by default. This can be changed
+using `usi.metrics.name-prefix` configuration parameter. Metric name components 
+are joined with dots. Components may have dashes in them.
+
+A metric type and a unit of measurement (if any) are appended to
+a metric name. A couple of examples:
+
+* `usi.scheduler.offers.counter`
+* `usi.scheduler.offers.processing-time.seconds`
+
+## Prometheus reporter
+
+The Prometheus reporter can be used to return a text representation of 
+current metrics and their values. Dots and dashes in metric names are 
+replaced with underscores.
+
+## StatsD reporter
+
+The StatsD reporter can be enabled with `usi.metrics.statsd-reporter` parameter. 
+It sends metrics over UDP to the host and port specified with
+`usi.metrics.reporters.statsd.host` and `usi.metrics.reporters.statsd.port` respectively.
+
+Counters are forwarded as gauges.
+
+## DataDog reporter
+
+The DataDog reporter can be enabled with `usi.metrics.datadog-reporter` parameter. 
+It sends metrics over UDP to the host and port specified with `usi.metrics.reporters.datadog.host` 
+and `usi.metrics.reporters.datadog.port` respectively.
+
+Metrics can be sent to a DataDog agent over UDP, or directly to
+the DataDog cloud over HTTP. It is specified using
+`usi.metrics.reporters.datadog.protocol`. Its possible values are `udp` (default)
+and `api`. If `api` is chosen, your DataDog API key can be supplied with
+`usi.metrics.reporters.datadog.api-key`.
+
+Dashes in metric names are replaced with underscores. Counters are
+forwarded as gauges.
+
+
+### JVM-specific metrics
+A selected set of JVM related metrics is collected by default.
+
+#### JVM buffer pools
+
+* `usi.jvm.buffers.mapped.gauge` — an estimate of the number of
+  mapped buffers.
+* `usi.jvm.buffers.mapped.capacity.gauge.bytes` — an estimate of
+  the total capacity of the mapped buffers in bytes.
+* `usi.jvm.buffers.mapped.memory.used.gauge.bytes` an estimate of
+  the memory that the JVM is using for mapped buffers in bytes, or `-1L`
+  if an estimate of the memory usage is not available.
+* `usi.jvm.buffers.direct.gauge` — an estimate of the number of
+  direct buffers.
+* `usi.jvm.buffers.direct.capacity.gauge.bytes` — an estimate of
+  the total capacity of the direct buffers in bytes.
+* `usi.jvm.buffers.direct.memory.used.gauge.bytes` an estimate of
+  the memory that the JVM is using for direct buffers in bytes, or `-1L`
+  if an estimate of the memory usage is not available.
+
+#### JVM garbage collection
+
+* `usi.jvm.gc.<gc>.collections.gauge` — the total number
+  of collections that have occurred
+* `usi.jvm.gc.<gc>.collections.duraration.gauge.seconds` — the
+  approximate accumulated collection elapsed time, or `-1` if the
+  collection elapsed time is undefined for the given collector.
+
+#### JVM memory
+
+* `usi.jvm.memory.total.init.gauge.bytes` - the amount of memory
+  in bytes that the JVM initially requests from the operating system
+  for memory management, or `-1` if the initial memory size is
+  undefined.
+* `usi.jvm.memory.total.used.gauge.bytes` - the amount of used
+  memory in bytes.
+* `usi.jvm.memory.total.max.gauge.bytes` - the maximum amount of
+  memory in bytes that can be used for memory management, `-1` if the
+  maximum memory size is undefined.
+* `usi.jvm.memory.total.committed.gauge.bytes` - the amount of
+  memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.heap.init.gauge.bytes` - the amount of heap
+  memory in bytes that the JVM initially requests from the operating
+  system for memory management, or `-1` if the initial memory size is
+  undefined.
+* `usi.jvm.memory.heap.used.gauge.bytes` - the amount of used heap
+  memory in bytes.
+* `usi.jvm.memory.heap.max.gauge.bytes` - the maximum amount of
+  heap memory in bytes that can be used for memory management, `-1` if
+  the maximum memory size is undefined.
+* `usi.jvm.memory.heap.committed.gauge.bytes` - the amount of heap
+  memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.heap.usage.gauge` - the ratio of
+  `usi.jvm.memory.heap.used.gauge.bytes` and
+  `usi.jvm.memory.heap.max.gauge.bytes`.
+* `usi.jvm.memory.non-heap.init.gauge.bytes` - the amount of
+  non-heap memory in bytes that the JVM initially requests from the
+  operating system for memory management, or `-1` if the initial memory
+  size is undefined.
+* `usi.jvm.memory.non-heap.used.gauge.bytes` - the amount of used
+  non-heap memory in bytes.
+* `usi.jvm.memory.non-heap.max.gauge.bytes` - the maximum amount of
+  non-heap memory in bytes that can be used for memory management, `-1`
+  if the maximum memory size is undefined.
+* `usi.jvm.memory.non-heap.committed.gauge.bytes` - the amount of
+  non-heap memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.non-heap.usage.gauge` - the ratio of
+  `usi.jvm.memory.non-heap.used.gauge.bytes` and
+  `usi.jvm.memory.non-heap.max.gauge.bytes`.
+
+#### JVM threads
+
+* `usi.jvm.threads.active.gauge` — the number of active threads.
+* `usi.jvm.threads.daemon.gauge` — the number of daemon threads.
+* `usi.jvm.threads.deadlocked.gauge` — the number of deadlocked
+  threads.
+* `usi.jvm.threads.new.gauge` — the number of threads in `NEW`
+   state.
+* `usi.jvm.threads.runnable.gauge` — the number of threads in
+  `RUNNABLE` state.
+* `usi.jvm.threads.blocked.gauge` — the number of threads in
+  `BLOCKED` state.
+* `usi.jvm.threads.timed-waiting.gauge` — the number of threads in
+  `TIMED_WAITING` state.
+* `usi.jvm.threads.waiting.gauge` — the number of threads in
+  `WAITING` state.
+* `usi.jvm.threads.terminated.gauge` — the number of threads in
+  `TERMINATED` state.

--- a/metrics-dropwizard/build.gradle
+++ b/metrics-dropwizard/build.gradle
@@ -1,22 +1,8 @@
-plugins {
-    id 'scala'
-}
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation project(':usi-metrics')
+    implementation project(':metrics')
+    compile group: 'com.github.vladimir-bukhtoyarov', name: 'rolling-metrics', version:  '2.0.4'
+    compile group: 'com.iheart', name: 'ficus_2.12', version: '1.4.3'
     compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.0.2'
     compile group: 'io.dropwizard.metrics', name: 'metrics-jvm', version: '4.0.2'
-    compile group: 'com.github.vladimir-bukhtoyarov', name: 'rolling-metrics', version:  '2.0.4'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version:  '2.1.10'
-
-    // Common project dependencies
-    compile group: 'org.rogach', name: 'scallop_2.12', version: '3.1.2'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    compile group: 'com.typesafe.scala-logging', name: 'scala-logging_2.12', version: '3.9.2'
-    compile group: 'com.typesafe.akka', name: 'akka-http_2.12', version: '10.0.11'
-    compile group: 'com.iheart', name: 'ficus_2.12', version: '1.4.3'
 }

--- a/metrics-dropwizard/build.gradle
+++ b/metrics-dropwizard/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'scala'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':usi-metrics')
+    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.0.2'
+    compile group: 'io.dropwizard.metrics', name: 'metrics-jvm', version: '4.0.2'
+    compile group: 'com.github.vladimir-bukhtoyarov', name: 'rolling-metrics', version:  '2.0.4'
+    compile group: 'org.hdrhistogram', name: 'HdrHistogram', version:  '2.1.10'
+
+    // Common project dependencies
+    compile group: 'org.rogach', name: 'scallop_2.12', version: '3.1.2'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    compile group: 'com.typesafe.scala-logging', name: 'scala-logging_2.12', version: '3.9.2'
+    compile group: 'com.typesafe.akka', name: 'akka-http_2.12', version: '10.0.11'
+    compile group: 'com.iheart', name: 'ficus_2.12', version: '1.4.3'
+}

--- a/metrics-dropwizard/build.gradle
+++ b/metrics-dropwizard/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     implementation project(':metrics')
     compile group: 'com.github.vladimir-bukhtoyarov', name: 'rolling-metrics', version:  '2.0.4'
-    compile group: 'com.iheart', name: 'ficus_2.12', version: '1.4.3'
-    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.0.2'
-    compile group: 'io.dropwizard.metrics', name: 'metrics-jvm', version: '4.0.2'
-    compile group: 'org.hdrhistogram', name: 'HdrHistogram', version:  '2.1.10'
+    compile group: 'com.iheart', name: 'ficus_2.12', version: '1.4.4'
+    compile group: 'io.dropwizard.metrics', name: 'metrics-core', version: '4.0.5'
+    compile group: 'io.dropwizard.metrics', name: 'metrics-jvm', version: '4.0.5'
+    compile group: 'org.hdrhistogram', name: 'HdrHistogram', version:  '2.1.11'
 }

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/BufferPoolMetricSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/BufferPoolMetricSet.java
@@ -1,0 +1,56 @@
+package com.mesosphere.usi.metrics.dropwizard;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.jvm.JmxAttributeGauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A set of gauges for the count, usage, and capacity of the JVM's direct and mapped buffer pools.
+ * <p>
+ * These JMX objects are only available on Java 7 and above.
+ *
+ * This is a copy of BufferPoolMetricSet from Dropwizard metrics, slightly adjusted to support USI metric name
+ * conventions.
+ */
+public class BufferPoolMetricSet implements MetricSet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BufferPoolMetricSet.class);
+    private static final String[] ATTRIBUTES = {"Count", "MemoryUsed", "TotalCapacity"};
+    private static final String[] NAMES = {"gauge", "memory.used.gauge.bytes", "capacity.gauge.bytes"};
+    private static final String[] POOLS = {"direct", "mapped"};
+
+    private final MBeanServer mBeanServer;
+
+    public BufferPoolMetricSet(MBeanServer mBeanServer) {
+        this.mBeanServer = mBeanServer;
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<>();
+        for (String pool : POOLS) {
+            for (int i = 0; i < ATTRIBUTES.length; i++) {
+                final String attribute = ATTRIBUTES[i];
+                final String name = NAMES[i];
+                try {
+                    final ObjectName on = new ObjectName("java.nio:type=BufferPool,name=" + pool);
+                    mBeanServer.getMBeanInfo(on);
+                    gauges.put(name(pool, name), new JmxAttributeGauge(mBeanServer, on, attribute));
+                } catch (JMException ex) {
+                    LOGGER.warn("Unable to load buffer pool MBeans, possibly running on Java 6", ex);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(gauges);
+    }
+}

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/GarbageCollectorMetricSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/GarbageCollectorMetricSet.java
@@ -1,0 +1,52 @@
+package com.mesosphere.usi.metrics.dropwizard;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A set of gauges for the counts and elapsed times of garbage collections.
+ *
+ * This is a copy of GarbageCollectorMetricSet from Dropwizard metrics, slightly adjusted to support USI metric name
+ * conventions.
+ */
+public class GarbageCollectorMetricSet implements MetricSet {
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+    private final List<GarbageCollectorMXBean> garbageCollectors;
+
+    /**
+     * Creates a new set of gauges for all discoverable garbage collectors.
+     */
+    public GarbageCollectorMetricSet() {
+        this(ManagementFactory.getGarbageCollectorMXBeans());
+    }
+
+    /**
+     * Creates a new set of gauges for the given collection of garbage collectors.
+     *
+     * @param garbageCollectors the garbage collectors
+     */
+    public GarbageCollectorMetricSet(Collection<GarbageCollectorMXBean> garbageCollectors) {
+        this.garbageCollectors = new ArrayList<>(garbageCollectors);
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<>();
+        for (final GarbageCollectorMXBean gc : garbageCollectors) {
+            final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-").toLowerCase(Locale.US);
+            gauges.put(name(name, "collections.gauge"), (Gauge<Long>) gc::getCollectionCount);
+            gauges.put(name(name, "collections.duration.gauge.seconds"),
+                    (Gauge<Double>) () -> (new Long(gc.getCollectionTime()).doubleValue()) / 1000.0);
+        }
+        return Collections.unmodifiableMap(gauges);
+    }
+}

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/GarbageCollectorMetricSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/GarbageCollectorMetricSet.java
@@ -6,14 +6,21 @@ import com.codahale.metrics.MetricSet;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * A set of gauges for the counts and elapsed times of garbage collections.
- *
+ * <p>
  * This is a copy of GarbageCollectorMetricSet from Dropwizard metrics, slightly adjusted to support USI metric name
  * conventions.
  */
@@ -45,7 +52,7 @@ public class GarbageCollectorMetricSet implements MetricSet {
             final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-").toLowerCase(Locale.US);
             gauges.put(name(name, "collections.gauge"), (Gauge<Long>) gc::getCollectionCount);
             gauges.put(name(name, "collections.duration.gauge.seconds"),
-                    (Gauge<Double>) () -> (new Long(gc.getCollectionTime()).doubleValue()) / 1000.0);
+                    (Gauge<Double>) () -> (gc.getCollectionTime()) / 1000.0);
         }
         return Collections.unmodifiableMap(gauges);
     }

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/MemoryUsageGaugeSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/MemoryUsageGaugeSet.java
@@ -1,0 +1,106 @@
+package com.mesosphere.usi.metrics.dropwizard;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.RatioGauge;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A set of gauges for JVM memory usage, including stats on heap vs. non-heap memory, plus
+ * GC-specific memory pools.
+ *
+ * This is a copy of MemoryUsageGaugeSet from Dropwizard metrics, slightly adjusted to support USI metric name
+ * conventions.
+ */
+public class MemoryUsageGaugeSet implements MetricSet {
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+    private final MemoryMXBean mxBean;
+    private final List<MemoryPoolMXBean> memoryPools;
+
+    public MemoryUsageGaugeSet() {
+        this(ManagementFactory.getMemoryMXBean(), ManagementFactory.getMemoryPoolMXBeans());
+    }
+
+    public MemoryUsageGaugeSet(MemoryMXBean mxBean,
+                               Collection<MemoryPoolMXBean> memoryPools) {
+        this.mxBean = mxBean;
+        this.memoryPools = new ArrayList<>(memoryPools);
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<>();
+
+        gauges.put("total.init.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit() +
+                mxBean.getNonHeapMemoryUsage().getInit());
+        gauges.put("total.used.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed() +
+                mxBean.getNonHeapMemoryUsage().getUsed());
+        gauges.put("total.max.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax() +
+                mxBean.getNonHeapMemoryUsage().getMax());
+        gauges.put("total.committed.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted() +
+                mxBean.getNonHeapMemoryUsage().getCommitted());
+
+        gauges.put("heap.init.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit());
+        gauges.put("heap.used.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed());
+        gauges.put("heap.max.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax());
+        gauges.put("heap.committed.gauge.bytes", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted());
+        gauges.put("heap.usage.gauge", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                final MemoryUsage usage = mxBean.getHeapMemoryUsage();
+                return Ratio.of(usage.getUsed(), usage.getMax());
+            }
+        });
+
+        gauges.put("non-heap.init.gauge.bytes", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getInit());
+        gauges.put("non-heap.used.gauge.bytes", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getUsed());
+        gauges.put("non-heap.max.gauge.bytes", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getMax());
+        gauges.put("non-heap.committed.gauge.bytes", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getCommitted());
+        gauges.put("non-heap.usage.gauge", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();
+                return Ratio.of(usage.getUsed(), usage.getMax());
+            }
+        });
+
+        for (final MemoryPoolMXBean pool : memoryPools) {
+            final String poolName = name("pools",
+                    WHITESPACE.matcher(pool.getName()).replaceAll("-").toLowerCase(Locale.US));
+
+            gauges.put(name(poolName, "usage.gauge"), new RatioGauge() {
+                @Override
+                protected Ratio getRatio() {
+                    MemoryUsage usage = pool.getUsage();
+                    return Ratio.of(usage.getUsed(),
+                            usage.getMax() == -1 ? usage.getCommitted() : usage.getMax());
+                }
+            });
+
+            gauges.put(name(poolName, "max.gauge.bytes"), (Gauge<Long>) () -> pool.getUsage().getMax());
+            gauges.put(name(poolName, "used.gauge.bytes"), (Gauge<Long>) () -> pool.getUsage().getUsed());
+            gauges.put(name(poolName, "committed.gauge.bytes"),
+                    (Gauge<Long>) () -> pool.getUsage().getCommitted());
+
+            // Only register GC usage metrics if the memory pool supports usage statistics.
+            if (pool.getCollectionUsage() != null) {
+                gauges.put(name(poolName, "used-after-gc.gauge.bytes"), (Gauge<Long>) () ->
+                        pool.getCollectionUsage().getUsed());
+            }
+
+            gauges.put(name(poolName, "init.gauge.bytes"), (Gauge<Long>) () -> pool.getUsage().getInit());
+        }
+
+        return Collections.unmodifiableMap(gauges);
+    }
+}

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/MemoryUsageGaugeSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/MemoryUsageGaugeSet.java
@@ -9,7 +9,13 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -17,7 +23,7 @@ import static com.codahale.metrics.MetricRegistry.name;
 /**
  * A set of gauges for JVM memory usage, including stats on heap vs. non-heap memory, plus
  * GC-specific memory pools.
- *
+ * <p>
  * This is a copy of MemoryUsageGaugeSet from Dropwizard metrics, slightly adjusted to support USI metric name
  * conventions.
  */

--- a/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/ThreadStatesGaugeSet.java
+++ b/metrics-dropwizard/src/main/java/com/mesosphere/usi/metrics/dropwizard/ThreadStatesGaugeSet.java
@@ -1,0 +1,82 @@
+package com.mesosphere.usi.metrics.dropwizard;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.jvm.ThreadDeadlockDetector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A set of gauges for the number of threads in their various states and deadlock detection.
+ *
+ * This is a copy of ThreadStatesGaugeSet from Dropwizard metrics, slightly adjusted to support USI metric name
+ * conventions.
+ */
+public class ThreadStatesGaugeSet implements MetricSet {
+
+    // do not compute stack traces.
+    private final static int STACK_TRACE_DEPTH = 0;
+
+    private final ThreadMXBean threads;
+    private final ThreadDeadlockDetector deadlockDetector;
+
+    /**
+     * Creates a new set of gauges using the default MXBeans.
+     */
+    public ThreadStatesGaugeSet() {
+        this(ManagementFactory.getThreadMXBean(), new ThreadDeadlockDetector());
+    }
+
+    /**
+     * Creates a new set of gauges using the given MXBean and detector.
+     *
+     * @param threads          a thread MXBean
+     * @param deadlockDetector a deadlock detector
+     */
+    public ThreadStatesGaugeSet(ThreadMXBean threads,
+                                ThreadDeadlockDetector deadlockDetector) {
+        this.threads = threads;
+        this.deadlockDetector = deadlockDetector;
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<>();
+
+        for (final Thread.State state : Thread.State.values()) {
+            String stateName = state.toString().toLowerCase().replace('_', '-');
+            gauges.put(name(stateName, "gauge"),
+                    (Gauge<Integer>) () -> getThreadCount(state));
+        }
+
+        gauges.put("active.gauge", (Gauge<Integer>) threads::getThreadCount);
+        gauges.put("daemon.gauge", (Gauge<Integer>) threads::getDaemonThreadCount);
+        gauges.put("deadlocked.gauge", (Gauge<Integer>) () -> deadlockDetector.getDeadlockedThreads().size());
+
+        return Collections.unmodifiableMap(gauges);
+    }
+
+    private Integer getThreadCount(Thread.State state) {
+        final ThreadInfo[] allThreads = getThreadInfo();
+        int count = 0;
+        for (ThreadInfo info : allThreads) {
+            if (info != null && info.getThreadState() == state) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    ThreadInfo[] getThreadInfo() {
+        return threads.getThreadInfo(threads.getAllThreadIds(), STACK_TRACE_DEPTH);
+    }
+
+}

--- a/metrics-dropwizard/src/main/resources/reference.conf
+++ b/metrics-dropwizard/src/main/resources/reference.conf
@@ -55,7 +55,7 @@ usi.metrics {
   #    protocol: "api"
   #
   #    # A DataDog API key
-  #    api-key: "FAKE-API-KEY"
+  #    api-key: ${?DATA_DOG_API_KEY}
   #
   #    # A transmission interval in milliseconds for the DataDog reporter.
   #    transmission-interval: 10000ms

--- a/metrics-dropwizard/src/main/resources/reference.conf
+++ b/metrics-dropwizard/src/main/resources/reference.conf
@@ -1,0 +1,63 @@
+usi.metrics {
+
+  # A prefix that is used when constructing metric names
+  name-prefix: "usi"
+
+  # Histogram realated settings
+  histogram {
+    # The highest trackable value of histograms and timers
+    reservoir-highest-trackable-value: 3600000000000
+
+    # The number of significant decimal digits to which histograms and timers will maintain value resolution and separation
+    reservoir-significant-digits: 3
+
+    # Clear histograms and timers fully according to the given interval
+    reservoir-reset-periodically: true
+
+    # A histogram resetting interval
+    reservoir-resetting-interval: 5000ms
+
+    # Histogram reservoirs are divided into this number of chunks, and one chunk is cleared after each (resetting interval / number of chunks) elapsed
+    reservoir-resetting-chunks: 0
+  }
+
+  # Enable StatsD reporter. If enabled, the `statsd-reporter` block should be enabled and
+  # host and port should be provided
+  statsd-reporter: off
+
+  # StatsD reporter
+  # reporters.statsd {
+  #   # A remote hostname for the StatsD reporter
+  #   host:
+  #
+  #   # A remote port for the StatsD reporter
+  #   port:
+  #
+  #   # A transmission interval for the StatsD reporter.
+  #   transmission-interval: 10000ms
+  # }
+
+  # Enable DataDog reporter. If enabled, the `datadog-reporter-on` block should be enabled
+  datadog-reporter: off
+
+  # DataDog reporter
+  #  reporters.datadog {
+  #    # A remote hostname for the DataDog reporter.
+  #    host:
+  #
+  #    # A remote port for the DataDog reporter.
+  #    port: 0
+  #
+  #    # A protocol to use with the DataDog reporter (default: udp; supported protocols: udp, api).
+  #    # When using "api" protocol, `api-key` should be provided. With "udp" protocol  host and port
+  #    # should be set.
+  #
+  #    protocol: "api"
+  #
+  #    # A DataDog API key
+  #    api-key: "FAKE-API-KEY"
+  #
+  #    # A transmission interval in milliseconds for the DataDog reporter.
+  #    transmission-interval: 10000ms
+  #  }
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/async/CallerThreadExecutionContext.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/async/CallerThreadExecutionContext.scala
@@ -1,0 +1,17 @@
+package com.mesosphere.usi.async
+
+import java.util.concurrent.Executor
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+
+object CallerThreadExecutionContext {
+  val executor: Executor = (command: Runnable) => command.run()
+
+  lazy val callerThreadExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(executor)
+
+  def apply(): ExecutionContext = callerThreadExecutionContext
+}
+
+object ExecutionContexts {
+  lazy val callerThread: ExecutionContext = CallerThreadExecutionContext()
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetrics.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetrics.scala
@@ -1,0 +1,111 @@
+package com.mesosphere.usi.metrics.dropwizard
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+import com.codahale
+import com.codahale.metrics
+import com.codahale.metrics.MetricRegistry
+import com.github.rollingmetrics.histogram.{HdrBuilder, OverflowResolver}
+import com.mesosphere.usi.metrics.dropwizard.conf.MetricsSettings
+import com.mesosphere.usi.metrics.{ClosureGauge, Counter, Gauge, Meter, Metrics, SettableGauge, Timer, TimerAdapter, UnitOfMeasurement}
+import mesosphere.marathon.metrics.HistogramTimer
+
+import scala.util.matching.Regex
+
+class DropwizardMetrics(metricsSettings: MetricsSettings, registry: MetricRegistry) extends Metrics {
+  import DropwizardMetrics.constructName
+
+  private val namePrefix = metricsSettings.namePrefix
+  private val histrogramSettings = metricsSettings.historgramSettings
+  private val histogramReservoirHighestTrackableValue = histrogramSettings.reservoirHighestTrackableValue
+  private val histogramReservoirSignificantDigits = histrogramSettings.reservoirSignificantDigits
+  private val histogramReservoirResetPeriodically = histrogramSettings.reservoirResetPeriodically
+  private val histogramReservoirResettingInterval = Duration.ofNanos(histrogramSettings.reservoirResettingInterval.toNanos)
+  private val histogramReservoirResettingChunks = histrogramSettings.reservoirResettingChunks
+
+  implicit class DropwizardCounter(val counter: codahale.metrics.Counter) extends Counter {
+    override def increment(): Unit = increment(1L)
+    override def increment(times: Long): Unit = counter.inc(times)
+  }
+  override def counter(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Counter = {
+    registry.counter(constructName(namePrefix, name, "counter", unit))
+  }
+
+  override def closureGauge[N](name: String, fn: () => N,
+    unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge = {
+    class DropwizardClosureGauge(val name: String) extends ClosureGauge {
+      registry.gauge(name, () => () => fn())
+    }
+    new DropwizardClosureGauge(constructName(namePrefix, name, "gauge", unit))
+  }
+
+  class DropwizardSettableGauge(val name: String) extends SettableGauge {
+    private[this] val register = new AtomicLong(0)
+    registry.gauge(name, () => () => register.get())
+
+    override def increment(by: Long): Unit = register.addAndGet(by)
+    override def decrement(by: Long): Unit = increment(-by)
+    override def value(): Long = register.get()
+    override def setValue(value: Long): Unit = register.set(value)
+  }
+  override def gauge(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Gauge = {
+    new DropwizardSettableGauge(constructName(namePrefix, name, "gauge", unit))
+  }
+  override def settableGauge(
+    name: String,
+    unit: UnitOfMeasurement = UnitOfMeasurement.None): SettableGauge = {
+    new DropwizardSettableGauge(constructName(namePrefix, name, "gauge", unit))
+  }
+
+  implicit class DropwizardMeter(val meter: codahale.metrics.Meter) extends Meter {
+    override def mark(): Unit = meter.mark()
+  }
+  override def meter(name: String): Meter = {
+    registry.meter(constructName(namePrefix, name, "meter", UnitOfMeasurement.None))
+  }
+
+  implicit class DropwizardTimerAdapter(val timer: metrics.Timer) extends TimerAdapter {
+    override def update(value: Long): Unit = timer.update(value, TimeUnit.NANOSECONDS)
+  }
+
+  override def timer(name: String): Timer = {
+    val effectiveName = constructName(namePrefix, name, "timer", UnitOfMeasurement.Time)
+
+    def makeTimer(): metrics.Timer = {
+      val reservoirBuilder = new HdrBuilder()
+        .withSignificantDigits(histogramReservoirSignificantDigits)
+        .withLowestDiscernibleValue(1)
+        .withHighestTrackableValue(histogramReservoirHighestTrackableValue, OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
+      if (histogramReservoirResetPeriodically) {
+        if (histogramReservoirResettingChunks == 0)
+          reservoirBuilder.resetReservoirPeriodically(histogramReservoirResettingInterval)
+        else
+          reservoirBuilder.resetReservoirPeriodicallyByChunks(histogramReservoirResettingInterval, histogramReservoirResettingChunks)
+      }
+      val reservoir = reservoirBuilder.buildReservoir()
+      new metrics.Timer(reservoir)
+    }
+
+    HistogramTimer(registry.timer(effectiveName, () => makeTimer()))
+  }
+}
+
+object DropwizardMetrics {
+  val validNameRegex: Regex = "^[a-zA-Z0-9\\-\\.]+$".r
+
+  def constructName(prefix: String, name: String, `type`: String, unit: UnitOfMeasurement): String = {
+    val unitSuffix = unit match {
+      case UnitOfMeasurement.None => ""
+      case UnitOfMeasurement.Time => ".seconds"
+      case UnitOfMeasurement.Memory => ".bytes"
+    }
+    val constructedName = s"$prefix.$name.${`type`}$unitSuffix"
+    constructedName match {
+      case validNameRegex() =>
+      case _ => throw new IllegalArgumentException(s"$name is not a valid metric name")
+    }
+    constructedName
+  }
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsModule.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsModule.scala
@@ -1,0 +1,41 @@
+package com.mesosphere.usi.metrics.dropwizard
+
+import java.lang.management.ManagementFactory
+
+import akka.Done
+import akka.actor.ActorRefFactory
+import com.codahale.metrics.MetricRegistry
+import com.mesosphere.usi.metrics.Metrics
+import com.mesosphere.usi.metrics.dropwizard.conf.{DataDogApiReporterSettings, DataDogUdpReporterSettings, MetricsSettings}
+import com.mesosphere.usi.metrics.dropwizard.reporters.{DataDogAPIReporter, DataDogUDPReporter, StatsDReporter}
+import com.typesafe.config.Config
+
+class DropwizardMetricsModule(config: Config) {
+
+  val metricsSettings = MetricsSettings.fromSubConfig(config)
+
+  private lazy val metricNamePrefix = metricsSettings.namePrefix
+  private lazy val registry: MetricRegistry = {
+    val r = new MetricRegistry
+    r.register(s"$metricNamePrefix.jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer))
+    r.register(s"$metricNamePrefix.jvm.gc", new GarbageCollectorMetricSet())
+    r.register(s"$metricNamePrefix.jvm.memory", new MemoryUsageGaugeSet())
+    r.register(s"$metricNamePrefix.jvm.threads", new ThreadStatesGaugeSet())
+    r
+  }
+  val metrics: Metrics = new DropwizardMetrics(metricsSettings, registry)
+
+  def snapshot(): MetricRegistry = registry
+
+  def start(actorRefFactory: ActorRefFactory): Done = {
+    metricsSettings.statsdReporterSettings.foreach(statsdSettings =>
+      actorRefFactory.actorOf(StatsDReporter.props(statsdSettings, registry), "StatsDReporter"))
+
+    metricsSettings.dataDogReporterSettings.foreach {
+      case s: DataDogUdpReporterSettings => actorRefFactory.actorOf(DataDogUDPReporter.props(s, registry), name = "DataDogUDPReporter")
+      case s: DataDogApiReporterSettings => actorRefFactory.actorOf(DataDogAPIReporter.props(s, registry), name = "DataDogAPIReporter")
+      case s => throw new IllegalArgumentException(s"Unsupported DataDog reporter typ: $s")
+    }
+    Done
+  }
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/HistogramTimer.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/HistogramTimer.scala
@@ -1,0 +1,89 @@
+package mesosphere.marathon
+package metrics
+
+import akka.stream.scaladsl.{Flow, Source}
+import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet, javadsl}
+import java.time.{Clock, Duration, Instant}
+
+import com.mesosphere.usi.async.ExecutionContexts
+import com.mesosphere.usi.metrics.{Timer, TimerAdapter}
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+/**
+  * Akka Graph Stage that measures the time from the start of the stream until the end of it, where start is defined as
+  * the instant the stream is materialized
+  */
+class TimedStage[T](timer: TimerAdapter, clock: Clock) extends GraphStage[FlowShape[T, T]] {
+  val in = Inlet[T]("timer.in")
+  val out = Outlet[T]("timer.out")
+
+  @scala.throws[Exception](classOf[Exception])
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+
+    val logic = new GraphStageLogic(shape) {
+      private val start: Instant = clock.instant
+
+      setHandler(in, new InHandler {
+        @scala.throws[Exception](classOf[Exception])
+        override def onPush(): Unit = push(out, grab(in))
+
+        @scala.throws[Exception](classOf[Exception])
+        override def onUpstreamFinish(): Unit = {
+          timer.update(Duration.between(start, clock.instant).toNanos)
+          super.onUpstreamFinish()
+        }
+
+        @scala.throws[Exception](classOf[Exception])
+        override def onUpstreamFailure(ex: Throwable): Unit = {
+          timer.update(Duration.between(start, clock.instant).toNanos)
+          super.onUpstreamFailure(ex)
+        }
+      })
+
+      setHandler(out, new OutHandler {
+        @scala.throws[Exception](classOf[Exception])
+        override def onPull(): Unit = pull(in)
+      })
+    }
+    logic
+  }
+
+  override def shape: FlowShape[T, T] = FlowShape.of(in, out)
+}
+
+case class HistogramTimer(timer: TimerAdapter) extends Timer {
+
+  def apply[T](f: => Future[T]): Future[T] = {
+    val start = System.nanoTime()
+    val future = try {
+      f
+    } catch {
+      case NonFatal(e) =>
+        timer.update(System.nanoTime() - start)
+        throw e
+    }
+    future.onComplete(_ => timer.update(System.nanoTime() - start))(ExecutionContexts.callerThread)
+    future
+  }
+
+  def forSource[T, M](f: => Source[T, M])(implicit clock: Clock = Clock.systemUTC): Source[T, M] = {
+    val src = f
+    val flow = Flow.fromGraph(new TimedStage[T](timer, clock))
+    val transformed = src.via(flow)
+    transformed
+  }
+
+  def blocking[T](f: => T): T = {
+    val start = System.nanoTime()
+    try {
+      f
+    } finally {
+      timer.update(System.nanoTime() - start)
+    }
+  }
+
+  def update(value: Long): Unit = timer.update(value)
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettings.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettings.scala
@@ -1,0 +1,100 @@
+package com.mesosphere.usi.metrics.dropwizard.conf
+
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
+import net.ceedubs.ficus.Ficus.{finiteDurationReader, toFicusConfig}
+
+case class HistorgramSettings(reservoirHighestTrackableValue: Long = 3600000000000L,
+                              reservoirSignificantDigits: Int = 3,
+                              reservoirResetPeriodically: Boolean = true,
+                              reservoirResettingInterval: FiniteDuration = 5.seconds,
+                              reservoirResettingChunks: Int = 0
+                             ) {
+  require(reservoirHighestTrackableValue > 1L, "reservoir-highest-trackable-value: should be > 1")
+  require(reservoirSignificantDigits >= 0 && reservoirSignificantDigits <= 5, "reservoir-significant-digits should be >= 0 and <= 5")
+  require(reservoirResettingInterval > Duration.Zero, "reservoir-resetting-interval should be > 0")
+  require(reservoirResettingChunks == 0 || reservoirResettingChunks >= 2, "reservoir-resetting-chunks should be == 0 or >= 2")
+}
+
+object HistorgramSettings {
+  def fromSubConfig(c: Config) = apply (
+    c.getLong("reservoir-highest-trackable-value"),
+    c.getInt("reservoir-significant-digits"),
+    c.getBoolean("reservoir-reset-periodically"),
+    c.as[FiniteDuration]("reservoir-resetting-interval"),
+    c.getInt("reservoir-resetting-chunks")
+  )
+}
+
+case class StatsdReporterSettings(host: String,
+                                  port: Int,
+                                  transmissionInterval: FiniteDuration = 10.seconds) {
+  require(host.nonEmpty, "StatsD reporter host should be defined")
+  require(port > 0, "StatsD reporter port should be defined")
+  require(transmissionInterval > Duration.Zero, "transmitiona-interavl should be > 0")
+}
+
+object StatsdReporterSettings {
+  def fromSubConfig(c: Config) = apply (
+    c.getString("host"),
+    c.getInt("port"),
+    c.as[FiniteDuration]("transmission-interval")
+  )
+}
+
+sealed trait DataDogReporterSettings
+
+case class DataDogUdpReporterSettings(host: String,
+                                      port: Int,
+                                      transmissionInterval: FiniteDuration = 10.seconds) extends DataDogReporterSettings {
+  require(host.nonEmpty, "DataDog reporter host should be defined")
+  require(port > 0, "DataDog reporter port should be > 0")
+  require(transmissionInterval > Duration.Zero, "transmitiona-interavl should be > 0")
+}
+
+case class DataDogApiReporterSettings(apiKey: String,
+                                      transmissionInterval: FiniteDuration = 10.seconds) extends DataDogReporterSettings {
+  require(transmissionInterval > Duration.Zero, "transmitiona-interavl should be > 0")
+}
+
+object DataDogReporterSettings {
+
+  def fromSubConfig(c: Config) = c.getString("protocol") match {
+    case "udp" => DataDogUdpReporterSettings(
+      c.getString("host"),
+      c.getInt("port"),
+      c.as[FiniteDuration]("transmission-interval")
+    )
+    case "api" => DataDogApiReporterSettings(
+      c.getString("api-key"),
+      c.as[FiniteDuration]("transmission-interval")
+    )
+    case p =>
+      throw new IllegalArgumentException(s"Protocol $p for the DataDog reporter is not supported. Please use 'udp' or 'api' instead")
+  }
+}
+
+case class MetricsSettings(namePrefix: String,
+                           historgramSettings: HistorgramSettings,
+                           statsdReporterSettings: Option[StatsdReporterSettings],
+                           dataDogReporterSettings: Option[DataDogReporterSettings]) {
+  require(namePrefix.nonEmpty, "name-prefix should not be empty")
+}
+
+object MetricsSettings {
+
+  def fromSubConfig(c: Config): MetricsSettings = apply(
+    c.getString("name-prefix"),
+    HistorgramSettings.fromSubConfig(c.getConfig("histogram")),
+    statsdReporterSettings =
+      if (c.getBoolean("statsd-reporter")) Some(
+        StatsdReporterSettings.fromSubConfig(c.getConfig("reporters.statsd")))
+      else None,
+    dataDogReporterSettings =
+      if (c.getBoolean("datadog-reporter")) Some(
+        DataDogReporterSettings.fromSubConfig(c.getConfig("reporters.datadog")))
+      else None
+  )
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogAPIReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogAPIReporter.scala
@@ -1,0 +1,149 @@
+package com.mesosphere.usi.metrics.dropwizard.reporters
+
+import java.net.InetAddress
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, Props}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest, HttpResponse, MediaTypes, StatusCodes}
+import akka.pattern.pipe
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.util.ByteString
+import com.codahale.metrics.{Counter, Gauge, Histogram, Metered, MetricRegistry, Snapshot, Timer}
+import com.mesosphere.usi.metrics.dropwizard.conf.DataDogApiReporterSettings
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.collection.JavaConverters._
+
+class DataDogAPIReporter(settings: DataDogApiReporterSettings, registry: MetricRegistry) extends Actor with StrictLogging {
+  private val apiKey = settings.apiKey
+  private val apiUrl = s"https://app.datadoghq.com/api/v1/series?api_key=$apiKey"
+  private val transmissionInterval = settings.transmissionInterval
+  private val http = Http(context.system)
+  private val host = InetAddress.getLocalHost.getHostName
+
+  private case object Tick
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
+
+  override def preStart(): Unit = {
+    self ! Tick
+  }
+
+  override def receive: Receive = {
+    case Tick =>
+      report()
+    case HttpResponse(code, _, entity, _) =>
+      if (code != StatusCodes.Accepted) {
+        entity.dataBytes.runFold(ByteString(""))(_ ++ _).foreach { body =>
+          logger.info(s"Got an unexpected response from DataDog: code=$code, body=$body")
+        }
+      } else {
+        entity.discardBytes()
+      }
+      context.system.scheduler.scheduleOnce(transmissionInterval, self, Tick)
+  }
+
+  private def report(): Unit = {
+    val buffer = new StringBuilder
+    val timestamp = Clock.systemUTC().instant().getEpochSecond
+
+    registry.getGauges.asScala.foreach { case (name, gauge) => reportGauge(buffer, sanitizeName(name), gauge, timestamp) }
+    registry.getCounters.asScala.foreach { case (name, counter) => reportCounter(buffer, sanitizeName(name), counter, timestamp) }
+    registry.getHistograms.asScala.foreach { case (name, histogram) => reportHistogram(buffer, sanitizeName(name), histogram, timestamp) }
+    registry.getMeters.asScala.foreach { case (name, value) => reportMetered(buffer, sanitizeName(name), value, timestamp) }
+    registry.getTimers.asScala.foreach { case (name, value) => reportTimer(buffer, sanitizeName(name), value, timestamp) }
+
+    val data = buffer
+      .insert(0, "{\"series\":[")
+      .append("]}")
+      .toString
+
+    val body = HttpEntity(MediaTypes.`application/json`, data)
+    http.singleRequest(HttpRequest(method = HttpMethods.POST, uri = apiUrl, entity = body)).pipeTo(self)
+  }
+
+  private val forbiddenCharsRe = "[^a-zA-Z0-9_.]".r
+  private def sanitizeName(name: String): String = forbiddenCharsRe.replaceAllIn(name, "_")
+
+  private val rateFactor = TimeUnit.SECONDS.toSeconds(1)
+  private val durationFactor = 1.0 / TimeUnit.SECONDS.toNanos(1)
+
+  private def reportGauge(buffer: StringBuilder, name: String, gauge: Gauge[_], timestamp: Long): Unit = {
+    val value: Number = gauge.getValue match {
+      case v: Double => if (v.isNaN) 0.0 else v
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
+      case v: Number => v
+    }
+
+    reportMetric(buffer, name, value.toString, timestamp, "gauge")
+  }
+
+  private def reportCounter(buffer: StringBuilder, name: String, counter: Counter, timestamp: Long): Unit =
+    reportMetric(buffer, name, counter.getCount.toString, timestamp, "gauge")
+
+  private val histogramSnapshotSuffixes =
+    Seq("min", "average", "median", "75percentile", "95percentile", "98percentile",
+      "99percentile", "999percentile", "max", "stddev")
+  private def reportSnapshot(buffer: StringBuilder, name: String, snapshot: Snapshot, timestamp: Long,
+    scaleMetrics: Boolean): Unit = {
+    val values = Seq(
+      snapshot.getMin.toDouble,
+      snapshot.getMean,
+      snapshot.getMedian,
+      snapshot.get75thPercentile(),
+      snapshot.get95thPercentile(),
+      snapshot.get98thPercentile(),
+      snapshot.get99thPercentile(),
+      snapshot.get999thPercentile(),
+      snapshot.getMax.toDouble,
+      snapshot.getStdDev)
+    val scaledValues = if (scaleMetrics) values.map(_ * durationFactor) else values
+
+    histogramSnapshotSuffixes.zip(scaledValues).foreach {
+      case (suffix, value) => reportMetric(buffer, s"$name.$suffix", value.toString, timestamp, "gauge")
+    }
+  }
+
+  private def reportHistogram(buffer: StringBuilder, name: String, histogram: Histogram, timestamp: Long): Unit = {
+    val count = histogram.getCount.toDouble
+    reportMetric(buffer, s"$name.count", count.toString, timestamp, "gauge")
+    reportSnapshot(buffer, name, histogram.getSnapshot, timestamp, false)
+  }
+
+  private val meteredSuffixes = Seq("count", "mean_rate", "m1_rate", "m5_rate", "m15_rate")
+  private def reportMetered(buffer: StringBuilder, name: String, meter: Metered, timestamp: Long): Unit = {
+    val values = Seq(
+      meter.getCount.toDouble,
+      meter.getMeanRate * rateFactor,
+      meter.getOneMinuteRate * rateFactor,
+      meter.getFiveMinuteRate * rateFactor,
+      meter.getFifteenMinuteRate * rateFactor)
+    meteredSuffixes.zip(values).foreach {
+      case (suffix, value) => reportMetric(buffer, s"$name.$suffix", value.toString, timestamp, "gauge")
+    }
+  }
+
+  private def reportTimer(buffer: StringBuilder, name: String, timer: Timer, timestamp: Long): Unit = {
+    val count = timer.getCount.toDouble
+    reportMetric(buffer, s"$name.count", count.toString, timestamp, "gauge")
+    val snapshot = timer.getSnapshot
+    reportSnapshot(buffer, name, snapshot, timestamp, true)
+    reportMetered(buffer, name, timer, timestamp)
+  }
+
+  private def reportMetric(buffer: StringBuilder, name: String, value: String, timestamp: Long,
+    metricType: String): Unit = {
+    if (buffer.length() > 0) buffer.append(',')
+    buffer.append(s"""{"metric":"$name","interval":$transmissionInterval,"points":[[$timestamp,$value]],"type":"$metricType",host:"$host"}""")
+  }
+}
+
+object DataDogAPIReporter {
+  def props(settings: DataDogApiReporterSettings, registry: MetricRegistry): Props = {
+    Props(new DataDogAPIReporter(settings, registry))
+  }
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogUDPReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogUDPReporter.scala
@@ -1,0 +1,158 @@
+package com.mesosphere.usi.metrics.dropwizard.reporters
+
+import java.net.InetSocketAddress
+import java.util
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.io.{IO, Udp}
+import akka.util.ByteString
+import com.codahale.metrics.{Counter, Gauge, Histogram, Meter, Metered, MetricRegistry, Snapshot, Timer}
+import com.mesosphere.usi.metrics.dropwizard.conf.DataDogUdpReporterSettings
+
+import scala.collection.JavaConverters._
+
+class DataDogUDPReporter(settings: DataDogUdpReporterSettings, registry: MetricRegistry) extends Actor {
+  private val remote: InetSocketAddress = {
+    val host = settings.host
+    val port = settings.port
+    new InetSocketAddress(host, port)
+  }
+  private val transmissionInterval = settings.transmissionInterval
+
+  private case object Tick
+
+  import context.system
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  IO(Udp) ! Udp.SimpleSender
+
+  def receive: PartialFunction[Any, Unit] = {
+    case Udp.SimpleSenderReady =>
+      self ! Tick
+      context.become(ready(sender()))
+  }
+
+  def ready(socket: ActorRef): Receive = {
+    case Tick =>
+      report(socket)
+      context.system.scheduler.scheduleOnce(transmissionInterval, self, Tick)
+  }
+
+  private def report(socket: ActorRef): Unit = {
+    report(
+      socket,
+      registry.getGauges, registry.getCounters, registry.getHistograms, registry.getMeters, registry.getTimers)
+  }
+
+  private def report(
+    socket: ActorRef,
+    gauges: util.SortedMap[String, Gauge[_]],
+    counters: util.SortedMap[String, Counter],
+    histograms: util.SortedMap[String, Histogram],
+    meters: util.SortedMap[String, Meter],
+    timers: util.SortedMap[String, Timer]): Unit = {
+
+    gauges.asScala.foreach { case (name, value) => reportGauge(socket, sanitizeName(name), value) }
+    counters.asScala.foreach { case (name, value) => reportCounter(socket, sanitizeName(name), value) }
+    histograms.asScala.foreach { case (name, value) => reportHistogram(socket, sanitizeName(name), value) }
+    meters.asScala.foreach { case (name, value) => reportMetered(socket, sanitizeName(name), value) }
+    timers.asScala.foreach { case (name, value) => reportTimer(socket, sanitizeName(name), value) }
+
+    flush(socket)
+  }
+
+  private val forbiddenCharsRe = "[^a-zA-Z0-9_.]".r
+  private def sanitizeName(name: String): String = forbiddenCharsRe.replaceAllIn(name, "_")
+
+  private val rateFactor = TimeUnit.SECONDS.toSeconds(1)
+  private val durationFactor = 1.0 / TimeUnit.SECONDS.toNanos(1)
+
+  private def reportGauge(socket: ActorRef, name: String, gauge: Gauge[_]): Unit = {
+    val value: Number = gauge.getValue match {
+      case v: Double => if (v.isNaN) 0.0 else v
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
+      case v: Number => v
+    }
+
+    maybeSendAndAppend(socket, s"$name:$value|g\n")
+  }
+
+  private def reportCounter(socket: ActorRef, name: String, counter: Counter): Unit =
+    maybeSendAndAppend(socket, s"$name:${counter.getCount}|g\n")
+
+  private val histogramSnapshotSuffixes =
+    Seq("min", "average", "median", "75percentile", "95percentile", "98percentile",
+      "99percentile", "999percentile", "max", "stddev")
+  private def reportSnapshot(socket: ActorRef, name: String, snapshot: Snapshot,
+    scaleMetrics: Boolean): Unit = {
+    val values = Seq(
+      snapshot.getMin.toDouble,
+      snapshot.getMean,
+      snapshot.getMedian,
+      snapshot.get75thPercentile(),
+      snapshot.get95thPercentile(),
+      snapshot.get98thPercentile(),
+      snapshot.get99thPercentile(),
+      snapshot.get999thPercentile(),
+      snapshot.getMax.toDouble,
+      snapshot.getStdDev)
+    val scaledValues = if (scaleMetrics) values.map(_ * durationFactor) else values
+
+    histogramSnapshotSuffixes.zip(scaledValues).foreach {
+      case (suffix, value) => maybeSendAndAppend(socket, s"$name.$suffix:$value|g\n")
+    }
+  }
+
+  private def reportHistogram(socket: ActorRef, name: String, histogram: Histogram): Unit = {
+    val count = histogram.getCount.toDouble
+    maybeSendAndAppend(socket, s"$name.count:$count|g\n")
+    reportSnapshot(socket, name, histogram.getSnapshot, false)
+  }
+
+  private val meteredSuffixes = Seq("count", "mean_rate", "m1_rate", "m5_rate", "m15_rate")
+  private def reportMetered(socket: ActorRef, name: String, meter: Metered): Unit = {
+    val values = Seq(
+      meter.getCount.toDouble,
+      meter.getMeanRate * rateFactor,
+      meter.getOneMinuteRate * rateFactor,
+      meter.getFiveMinuteRate * rateFactor,
+      meter.getFifteenMinuteRate * rateFactor)
+    meteredSuffixes.zip(values).foreach {
+      case (suffix, value) => maybeSendAndAppend(socket, s"$name.$suffix:$value|g\n")
+    }
+  }
+
+  private def reportTimer(socket: ActorRef, name: String, timer: Timer): Unit = {
+    val count = timer.getCount.toDouble
+    maybeSendAndAppend(socket, s"$name.count:$count|g\n")
+    val snapshot = timer.getSnapshot
+    reportSnapshot(socket, name, snapshot, true)
+    reportMetered(socket, name, timer)
+  }
+
+  val maxPayloadSize = 508 // the maximum safe UDP payload size
+  val buffer = new StringBuilder
+
+  private def maybeSendAndAppend(socket: ActorRef, measurement: String): Unit = {
+    require(measurement.length <= maxPayloadSize, "measurement length is too large")
+
+    if (buffer.length + measurement.length > maxPayloadSize)
+      flush(socket)
+    buffer.append(measurement)
+  }
+
+  private def flush(socket: ActorRef): Unit = {
+    if (buffer.nonEmpty) {
+      socket ! Udp.Send(ByteString(buffer.toString()), remote)
+      buffer.clear()
+    }
+  }
+}
+
+object DataDogUDPReporter {
+  def props(settings: DataDogUdpReporterSettings, registry: MetricRegistry): Props = {
+    Props(new DataDogUDPReporter(settings, registry))
+  }
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/PrometheusReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/PrometheusReporter.scala
@@ -1,0 +1,165 @@
+package com.mesosphere.usi.metrics.dropwizard.reporters
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.{Counter, Gauge, Histogram, Meter, Metered, MetricRegistry, Timer}
+
+import scala.collection.JavaConverters._
+
+object PrometheusReporter {
+  def report(registry: MetricRegistry): String = {
+    report(registry.getGauges, registry.getCounters, registry.getHistograms, registry.getMeters, registry.getTimers)
+  }
+
+  private def report(
+    gauges: util.SortedMap[String, Gauge[_]],
+    counters: util.SortedMap[String, Counter],
+    histograms: util.SortedMap[String, Histogram],
+    meters: util.SortedMap[String, Meter],
+    timers: util.SortedMap[String, Timer]): String = {
+
+    val buffer = new StringBuilder
+
+    gauges.asScala.foreach { case (name, value) => reportGauge(buffer, sanitizeName(name), value) }
+    counters.asScala.foreach { case (name, value) => reportCounter(buffer, sanitizeName(name), value) }
+    histograms.asScala.foreach { case (name, value) => reportHistogram(buffer, sanitizeName(name), value) }
+    meters.asScala.foreach { case (name, value) => reportMetered(buffer, sanitizeName(name), value) }
+    timers.asScala.foreach { case (name, value) => reportTimer(buffer, sanitizeName(name), value) }
+
+    buffer.toString()
+  }
+
+  private val forbiddenCharsRe = "[^a-zA-Z0-9_]".r
+  private def sanitizeName(name: String): String = forbiddenCharsRe.replaceAllIn(name, "_")
+
+  private def reportGauge(buffer: StringBuilder, name: String, gauge: Gauge[_]): Unit = {
+    val value: Number = gauge.getValue match {
+      case v: Double => if (v.isNaN) 0.0 else v
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
+      case v: Number => v
+    }
+    appendMetricType(buffer, name, "gauge")
+    appendLine(buffer, s"$name $value")
+    appendEmptyLine(buffer)
+  }
+
+  private def reportCounter(buffer: StringBuilder, name: String, counter: Counter): Unit = {
+    appendMetricType(buffer, name, "counter")
+    appendLine(buffer, s"$name ${counter.getCount}")
+    appendEmptyLine(buffer)
+  }
+
+  private val rateFactor = TimeUnit.SECONDS.toSeconds(1)
+  private val durationFactor = 1.0 / TimeUnit.SECONDS.toNanos(1)
+
+  private def reportHistogram(buffer: StringBuilder, name: String, histogram: Histogram): Unit = {
+    val count = histogram.getCount
+    val snapshot = histogram.getSnapshot
+
+    val min = snapshot.getMin
+    val mean = snapshot.getMean
+    val max = snapshot.getMax
+    val p50 = snapshot.getMedian
+    val p75 = snapshot.get75thPercentile()
+    val p95 = snapshot.get95thPercentile()
+    val p98 = snapshot.get98thPercentile()
+    val p99 = snapshot.get99thPercentile()
+    val p999 = snapshot.get999thPercentile()
+    val stddev = snapshot.getStdDev
+
+    appendMetricType(buffer, name, "summary")
+    appendLine(buffer, """%s{quantile="0.5"} %f""".format(name, p50))
+    appendLine(buffer, """%s{quantile="0.75"} %f""".format(name, p75))
+    appendLine(buffer, """%s{quantile="0.95"} %f""".format(name, p95))
+    appendLine(buffer, """%s{quantile="0.98"} %f""".format(name, p98))
+    appendLine(buffer, """%s{quantile="0.99"} %f""".format(name, p99))
+    appendLine(buffer, """%s{quantile="0.999"} %f""".format(name, p999))
+    appendLine(buffer, s"${name}_count $count")
+
+    appendMetricType(buffer, name + "_min", "gauge")
+    appendLine(buffer, s"${name}_min $min")
+    appendMetricType(buffer, name + "_mean", "gauge")
+    appendLine(buffer, s"${name}_mean $mean")
+    appendMetricType(buffer, name + "_max", "gauge")
+    appendLine(buffer, s"${name}_max $max")
+    appendMetricType(buffer, name + "_stddev", "gauge")
+    appendLine(buffer, s"${name}_stddev $stddev")
+
+    appendEmptyLine(buffer)
+  }
+
+  private def reportRates(buffer: StringBuilder, name: String, metered: Metered): Unit = {
+    val meanRate = metered.getMeanRate * rateFactor
+    val m1Rate = metered.getOneMinuteRate * rateFactor
+    val m5Rate = metered.getFiveMinuteRate * rateFactor
+    val m15Rate = metered.getFifteenMinuteRate * rateFactor
+
+    appendMetricType(buffer, name + "_mean_rate", "gauge")
+    appendLine(buffer, s"${name}_mean_rate $meanRate")
+    appendMetricType(buffer, name + "_m1_rate", "gauge")
+    appendLine(buffer, s"${name}_m1_rate $m1Rate")
+    appendMetricType(buffer, name + "_m5_rate", "gauge")
+    appendLine(buffer, s"${name}_m5_rate $m5Rate")
+    appendMetricType(buffer, name + "_m15_rate", "gauge")
+    appendLine(buffer, s"${name}_m15_rate $m15Rate")
+  }
+
+  private def reportMetered(buffer: StringBuilder, name: String, meter: Metered): Unit = {
+    val count = meter.getCount
+
+    appendMetricType(buffer, name + "_count", "gauge")
+    appendLine(buffer, s"${name}_count $count")
+    reportRates(buffer, name, meter)
+    appendEmptyLine(buffer)
+  }
+
+  private def reportTimer(buffer: StringBuilder, name: String, timer: Timer): Unit = {
+    val count = timer.getCount
+    val snapshot = timer.getSnapshot
+
+    val min = snapshot.getMin * durationFactor
+    val mean = snapshot.getMean * durationFactor
+    val max = snapshot.getMax * durationFactor
+    val p50 = snapshot.getMedian * durationFactor
+    val p75 = snapshot.get75thPercentile() * durationFactor
+    val p95 = snapshot.get95thPercentile() * durationFactor
+    val p98 = snapshot.get98thPercentile() * durationFactor
+    val p99 = snapshot.get99thPercentile() * durationFactor
+    val p999 = snapshot.get999thPercentile() * durationFactor
+    val stddev = snapshot.getStdDev * durationFactor
+
+    appendMetricType(buffer, name, "summary")
+    appendLine(buffer, """%s{quantile="0.5"} %f""".format(name, p50))
+    appendLine(buffer, """%s{quantile="0.75"} %f""".format(name, p75))
+    appendLine(buffer, """%s{quantile="0.95"} %f""".format(name, p95))
+    appendLine(buffer, """%s{quantile="0.98"} %f""".format(name, p98))
+    appendLine(buffer, """%s{quantile="0.99"} %f""".format(name, p99))
+    appendLine(buffer, """%s{quantile="0.999"} %f""".format(name, p999))
+    appendLine(buffer, s"${name}_count $count")
+
+    appendMetricType(buffer, name + "_min", "gauge")
+    appendLine(buffer, s"${name}_min $min")
+    appendMetricType(buffer, name + "_mean", "gauge")
+    appendLine(buffer, s"${name}_mean $mean")
+    appendMetricType(buffer, name + "_max", "gauge")
+    appendLine(buffer, s"${name}_max $max")
+    appendMetricType(buffer, name + "_stddev", "gauge")
+    appendLine(buffer, s"${name}_stddev $stddev")
+
+    reportRates(buffer, name, timer)
+
+    appendEmptyLine(buffer)
+  }
+
+  private def appendMetricType(buffer: StringBuilder, name: String, metricType: String): Unit = {
+    appendLine(buffer, s"# TYPE $name $metricType")
+  }
+
+  private def appendLine(buffer: StringBuilder, line: String): Unit = {
+    buffer.append(line)
+    buffer.append('\n')
+  }
+
+  private def appendEmptyLine(buffer: StringBuilder): Unit = buffer.append('\n')
+}

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/StatsDReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/StatsDReporter.scala
@@ -1,0 +1,155 @@
+package com.mesosphere.usi.metrics.dropwizard.reporters
+
+import java.net.InetSocketAddress
+import java.util
+import java.util.concurrent.TimeUnit
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.io.{IO, Udp}
+import akka.util.ByteString
+import com.codahale.metrics.{Counter, Gauge, Histogram, Meter, Metered, MetricRegistry, Snapshot, Timer}
+import com.mesosphere.usi.metrics.dropwizard.conf.StatsdReporterSettings
+
+import scala.collection.JavaConverters._
+
+class StatsDReporter(settings: StatsdReporterSettings, registry: MetricRegistry) extends Actor {
+  private val remote: InetSocketAddress = {
+    val host = settings.host
+    val port = settings.port
+    new InetSocketAddress(host, port)
+  }
+  private val transmissionInterval= settings.transmissionInterval
+
+  private case object Tick
+
+  import context.system
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  IO(Udp) ! Udp.SimpleSender
+
+  def receive: PartialFunction[Any, Unit] = {
+    case Udp.SimpleSenderReady =>
+      self ! Tick
+      context.become(ready(sender()))
+  }
+
+  def ready(socket: ActorRef): Receive = {
+    case Tick =>
+      report(socket)
+      context.system.scheduler.scheduleOnce(transmissionInterval, self, Tick)
+  }
+
+  private def report(socket: ActorRef): Unit = {
+    report(
+      socket,
+      registry.getGauges, registry.getCounters, registry.getHistograms, registry.getMeters, registry.getTimers)
+  }
+
+  private def report(
+    socket: ActorRef,
+    gauges: util.SortedMap[String, Gauge[_]],
+    counters: util.SortedMap[String, Counter],
+    histograms: util.SortedMap[String, Histogram],
+    meters: util.SortedMap[String, Meter],
+    timers: util.SortedMap[String, Timer]): Unit = {
+
+    gauges.asScala.foreach { case (name, value) => reportGauge(socket, name, value) }
+    counters.asScala.foreach { case (name, value) => reportCounter(socket, name, value) }
+    histograms.asScala.foreach { case (name, value) => reportHistogram(socket, name, value) }
+    meters.asScala.foreach { case (name, value) => reportMetered(socket, name, value) }
+    timers.asScala.foreach { case (name, value) => reportTimer(socket, name, value) }
+
+    flush(socket)
+  }
+
+  private val rateFactor = TimeUnit.SECONDS.toSeconds(1)
+  private val durationFactor = 1.0 / TimeUnit.SECONDS.toNanos(1)
+
+  private def reportGauge(socket: ActorRef, name: String, gauge: Gauge[_]): Unit = {
+    val value: Number = gauge.getValue match {
+      case v: Double => if (v.isNaN) 0.0 else v
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
+      case v: Number => v
+    }
+
+    maybeSendAndAppend(socket, s"$name:$value|g\n")
+  }
+
+  private def reportCounter(socket: ActorRef, name: String, counter: Counter): Unit =
+    maybeSendAndAppend(socket, s"$name:${counter.getCount}|g\n")
+
+  private val histogramSnapshotSuffixes =
+    Seq("min", "mean", "p50", "p75", "p95", "p98", "p99", "p999", "max", "stddev")
+  private def reportSnapshot(socket: ActorRef, name: String, snapshot: Snapshot,
+    scaleMetrics: Boolean): Unit = {
+    val values = Seq(
+      snapshot.getMin.toDouble,
+      snapshot.getMean,
+      snapshot.getMedian,
+      snapshot.get75thPercentile(),
+      snapshot.get95thPercentile(),
+      snapshot.get98thPercentile(),
+      snapshot.get99thPercentile(),
+      snapshot.get999thPercentile(),
+      snapshot.getMax.toDouble,
+      snapshot.getStdDev)
+    val scaledValues = if (scaleMetrics) values.map(_ * durationFactor) else values
+
+    histogramSnapshotSuffixes.zip(scaledValues).foreach {
+      case (suffix, value) => maybeSendAndAppend(socket, s"$name.$suffix:$value|g\n")
+    }
+  }
+
+  private def reportHistogram(socket: ActorRef, name: String, histogram: Histogram): Unit = {
+    val count = histogram.getCount.toDouble
+    maybeSendAndAppend(socket, s"$name.count:$count|g\n")
+    reportSnapshot(socket, name, histogram.getSnapshot, false)
+  }
+
+  private val meteredSuffixes = Seq("count", "mean_rate", "m1_rate", "m5_rate", "m15_rate")
+  private def reportMetered(socket: ActorRef, name: String, meter: Metered): Unit = {
+    val values = Seq(
+      meter.getCount.toDouble,
+      meter.getMeanRate * rateFactor,
+      meter.getOneMinuteRate * rateFactor,
+      meter.getFiveMinuteRate * rateFactor,
+      meter.getFifteenMinuteRate * rateFactor)
+    meteredSuffixes.zip(values).foreach {
+      case (suffix, value) => maybeSendAndAppend(socket, s"$name.$suffix:$value|g\n")
+    }
+  }
+
+  private def reportTimer(socket: ActorRef, name: String, timer: Timer): Unit = {
+    val count = timer.getCount.toDouble
+    maybeSendAndAppend(socket, s"$name.count:$count|g\n")
+    val snapshot = timer.getSnapshot
+    reportSnapshot(socket, name, snapshot, true)
+    reportMetered(socket, name, timer)
+  }
+
+  val maxPayloadSize = 508 // the maximum safe UDP payload size
+  val buffer = new StringBuilder
+
+  private def maybeSendAndAppend(socket: ActorRef, measurement: String): Unit = {
+    require(measurement.length <= maxPayloadSize, "measurement length is too large")
+
+    if (buffer.length + measurement.length > maxPayloadSize)
+      flush(socket)
+    buffer.append(measurement)
+  }
+
+  private def flush(socket: ActorRef): Unit = {
+    if (buffer.nonEmpty) {
+      socket ! Udp.Send(ByteString(buffer.toString()), remote)
+      buffer.clear()
+    }
+  }
+}
+
+object StatsDReporter {
+  def props(settings: StatsdReporterSettings, registry: MetricRegistry): Props = {
+    Props(new StatsDReporter(settings, registry))
+  }
+
+}

--- a/metrics-dropwizard/src/test/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsTest.scala
+++ b/metrics-dropwizard/src/test/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsTest.scala
@@ -1,0 +1,39 @@
+package com.mesosphere.usi.metrics.dropwizard
+
+import com.mesosphere.usi.metrics.UnitOfMeasurement
+import org.scalatest.{Matchers, WordSpec}
+
+class DropwizardMetricsTest extends WordSpec with Matchers {
+
+  "DropwizardMetrics.constructName" should {
+    "not append a unit of measurement suffix, when none is given" in {
+      val name =
+        DropwizardMetrics.constructName("marathon", "metric", "counter", UnitOfMeasurement.None)
+      name shouldBe "marathon.metric.counter"
+    }
+
+    "append the memory unit of measurement suffix, when it is given" in {
+      val name =
+        DropwizardMetrics.constructName("marathon", "metric", "counter", UnitOfMeasurement.Memory)
+      name shouldBe "marathon.metric.counter.bytes"
+    }
+
+    "append the time unit of measurement suffix, when it is given" in {
+      val name =
+        DropwizardMetrics.constructName("marathon", "metric", "counter", UnitOfMeasurement.Time)
+      name shouldBe "marathon.metric.counter.seconds"
+    }
+
+    "throw an exception if metric name components contain a disallowed character" in {
+      assertThrows[IllegalArgumentException] {
+        DropwizardMetrics.constructName("marathon#", "metric", "counter", UnitOfMeasurement.None)
+      }
+      assertThrows[IllegalArgumentException] {
+        DropwizardMetrics.constructName("marathon", "metric$", "counter", UnitOfMeasurement.None)
+      }
+      assertThrows[IllegalArgumentException] {
+        DropwizardMetrics.constructName("marathon", "metric", "counter%", UnitOfMeasurement.None)
+      }
+    }
+  }
+}

--- a/metrics-dropwizard/src/test/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettingsTest.scala
+++ b/metrics-dropwizard/src/test/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettingsTest.scala
@@ -1,0 +1,160 @@
+package com.mesosphere.usi.metrics.dropwizard.conf
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{GivenWhenThen, Inside, Matchers, OptionValues, WordSpec}
+
+import scala.concurrent.duration._
+
+class MetricsSettingsTest extends WordSpec
+  with Matchers
+  with GivenWhenThen
+  with Inside
+  with OptionValues {
+
+  "MetricsSettings" should {
+    "parse reference.conf correctly" in {
+      When("configuration is loaded")
+      val config = ConfigFactory.load()
+
+      Then("it can be successfully parsed")
+      val settings = MetricsSettings.fromSubConfig(config.getConfig("usi.metrics"))
+
+      And("values are set correctly")
+      settings.namePrefix shouldBe "usi"
+      val historgramSettings = settings.historgramSettings
+      historgramSettings.reservoirHighestTrackableValue shouldBe 3600000000000L
+      historgramSettings.reservoirSignificantDigits shouldBe 3
+      historgramSettings.reservoirResetPeriodically shouldBe true
+      historgramSettings.reservoirResettingInterval shouldBe 5.seconds
+      historgramSettings.reservoirResettingChunks shouldBe 0
+      settings.dataDogReporterSettings shouldBe None
+      settings.statsdReporterSettings shouldBe None
+    }
+
+    "parse a configuration with an enabled StatsD reporter" in {
+      Given("a configuration with statsd reporter")
+      val conf =
+        """
+          |usi.metrics {
+          |  name-prefix: "usi"
+          |  histogram {
+          |    reservoir-highest-trackable-value: 3600000000000
+          |    reservoir-significant-digits: 3
+          |    reservoir-reset-periodically: true
+          |    reservoir-resetting-interval: 5000ms
+          |    reservoir-resetting-chunks: 0
+          |  }
+          |
+          |  statsd-reporter: on
+          |  # StatsD reporter
+          |    reporters.statsd {
+          |        host: "localhost"
+          |        port: 8125
+          |        transmission-interval: 10000ms
+          |    }
+          |
+          |  datadog-reporter: off
+          |}
+        """.stripMargin
+
+      When("configuration is loaded")
+      val config = ConfigFactory.parseString(conf)
+
+      Then("it can be successfully parsed")
+      val settings = MetricsSettings.fromSubConfig(config.getConfig("usi.metrics"))
+
+      And("StatsD reporter settings are set correctly")
+      inside(settings.statsdReporterSettings.value) {
+        case StatsdReporterSettings(host, port, transmissionInterval) =>
+          host shouldBe "localhost"
+          port shouldBe 8125
+          transmissionInterval shouldBe 10.seconds
+      }
+    }
+
+    "parse a configuration with an enabled DataDog API reporter" in {
+      Given("a configuration with statsd reporter")
+      val conf =
+        """
+          |usi.metrics {
+          |  name-prefix: "usi"
+          |  histogram {
+          |    reservoir-highest-trackable-value: 3600000000000
+          |    reservoir-significant-digits: 3
+          |    reservoir-reset-periodically: true
+          |    reservoir-resetting-interval: 5000ms
+          |    reservoir-resetting-chunks: 0
+          |  }
+          |
+          |  statsd-reporter: off
+          |
+          |  datadog-reporter: on
+          |  # DataDog settings
+          |  reporters.datadog {
+          |    # host:
+          |    # port:
+          |    protocol: "api"
+          |    api-key: "FAKE-API-KEY"
+          |    transmission-interval: 10000ms
+          |  }
+          |}
+        """.stripMargin
+
+      When("configuration is loaded")
+      val config = ConfigFactory.parseString(conf)
+
+      Then("it can be successfully parsed")
+      val settings = MetricsSettings.fromSubConfig(config.getConfig("usi.metrics"))
+
+      And("DataDog API reporter settings are set correctly")
+      inside(settings.dataDogReporterSettings.value) {
+        case DataDogApiReporterSettings(apiKey, transmissionInterval) =>
+          apiKey shouldBe "FAKE-API-KEY"
+          transmissionInterval shouldBe 10.seconds
+      }
+    }
+
+    "parse a configuration with an enabled DataDog UDP reporter" in {
+      Given("a configuration with statsd reporter")
+      val conf =
+        """
+          |usi.metrics {
+          |  name-prefix: "usi"
+          |  histogram {
+          |    reservoir-highest-trackable-value: 3600000000000
+          |    reservoir-significant-digits: 3
+          |    reservoir-reset-periodically: true
+          |    reservoir-resetting-interval: 5000ms
+          |    reservoir-resetting-chunks: 0
+          |  }
+          |
+          |  statsd-reporter: off
+          |
+          |  datadog-reporter: on
+          |  # DataDog settings
+          |  reporters.datadog {
+          |    host: localhost
+          |    port: 8080
+          |    protocol: "udp"
+          |    # api-key:
+          |    transmission-interval: 10000ms
+          |  }
+          |}
+        """.stripMargin
+
+      When("configuration is loaded")
+      val config = ConfigFactory.parseString(conf)
+
+      Then("it can be successfully parsed")
+      val settings = MetricsSettings.fromSubConfig(config.getConfig("usi.metrics"))
+
+      And("DataDog API reporter settings are set correctly")
+      inside(settings.dataDogReporterSettings.value) {
+        case DataDogUdpReporterSettings(host, port, transmissionInterval) =>
+          host shouldBe "localhost"
+          port shouldBe 8080
+          transmissionInterval shouldBe 10.seconds
+      }
+    }
+  }
+}

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,163 @@
+# Metrics
+
+This is a [Dropwizard Metrics](https://github.com/dropwizard/metrics) implementation 
+of the USI metrics interface. It supports multiple exporters ([DataDog(https://www.datadoghq.com/)],
+[StatsD](https://github.com/etsy/statsd)) as well as text representation in 
+[Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) format.
+
+## Metric types
+
+USI has the following metric types:
+
+* a `counter` is a monotonically increasing integer, for instance, the
+  number of Mesos `revive` calls performed since Marathon became
+  a leader.
+* a `gauge` is a current measurement, for instance, the number of apps
+  currently known to Marathon.
+* a `histogram` is a distribution of values in a stream of measurements,
+  for instance, the number of apps in group deployments.
+* a `meter` measures the rate at which a set of events occur.
+* a `timer` is a combination of a meter and a histogram, which measure
+  the duration of events and the rate of their occurrence.
+
+Histograms and timers are backed with reservoirs leveraging
+[HdrHistogram](http://hdrhistogram.org/).
+
+## Units of measurement
+
+A metric measures something either in abstract quantities, or in the
+following units:
+
+* `bytes`
+* `seconds`
+
+## Metric names
+
+All metric names are prefixed with `usi` by default. This can be changed
+using `metrics_name_prefix` configuration parameter. Metric name components 
+are joined with dots. Components may have dashes in them.
+
+A metric type and a unit of measurement (if any) are appended to
+a metric name. A couple of examples:
+
+* `usi.scheduler.offers.counter`
+* `usi.scheduler.offers.processing-time.seconds`
+
+## Prometheus reporter
+
+The Prometheus reporter can be used to return a text representation of 
+current metrics and their values. Dots and dashes in metric names are 
+replaced with underscores.
+
+## StatsD reporter
+
+The StatsD reporter can be enabled with `metrics_statsd` parameter. 
+It sends metrics over UDP to the host and port specified with
+`metrics_statsd_host` and `metrics_statsd_port` respectively.
+
+Counters are forwarded as gauges.
+
+## DataDog reporter
+
+The DataDog reporter can be enabled with `metrics_datadog` parameter. 
+It sends metrics over UDP to the host and port specified with `metrics_datadog_host` 
+and `metrics_datadog_port` respectively.
+
+Metrics can be sent to a DataDog agent over UDP, or directly to
+the DataDog cloud over HTTP. It is specified using
+`metrics_datadog_protocol`. Its possible values are `udp` (default)
+and `api`. If `api` is chosen, your DataDog API key can be supplied with
+`metrics_datadog_api_key`.
+
+Dashes in metric names are replaced with underscores. Counters are
+forwarded as gauges.
+
+
+### JVM-specific metrics
+A selected set of JVM related metrics is collected by default.
+
+#### JVM buffer pools
+
+* `usi.jvm.buffers.mapped.gauge` — an estimate of the number of
+  mapped buffers.
+* `usi.jvm.buffers.mapped.capacity.gauge.bytes` — an estimate of
+  the total capacity of the mapped buffers in bytes.
+* `usi.jvm.buffers.mapped.memory.used.gauge.bytes` an estimate of
+  the memory that the JVM is using for mapped buffers in bytes, or `-1L`
+  if an estimate of the memory usage is not available.
+* `usi.jvm.buffers.direct.gauge` — an estimate of the number of
+  direct buffers.
+* `usi.jvm.buffers.direct.capacity.gauge.bytes` — an estimate of
+  the total capacity of the direct buffers in bytes.
+* `usi.jvm.buffers.direct.memory.used.gauge.bytes` an estimate of
+  the memory that the JVM is using for direct buffers in bytes, or `-1L`
+  if an estimate of the memory usage is not available.
+
+#### JVM garbage collection
+
+* `usi.jvm.gc.<gc>.collections.gauge` — the total number
+  of collections that have occurred
+* `usi.jvm.gc.<gc>.collections.duraration.gauge.seconds` — the
+  approximate accumulated collection elapsed time, or `-1` if the
+  collection elapsed time is undefined for the given collector.
+
+#### JVM memory
+
+* `usi.jvm.memory.total.init.gauge.bytes` - the amount of memory
+  in bytes that the JVM initially requests from the operating system
+  for memory management, or `-1` if the initial memory size is
+  undefined.
+* `usi.jvm.memory.total.used.gauge.bytes` - the amount of used
+  memory in bytes.
+* `usi.jvm.memory.total.max.gauge.bytes` - the maximum amount of
+  memory in bytes that can be used for memory management, `-1` if the
+  maximum memory size is undefined.
+* `usi.jvm.memory.total.committed.gauge.bytes` - the amount of
+  memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.heap.init.gauge.bytes` - the amount of heap
+  memory in bytes that the JVM initially requests from the operating
+  system for memory management, or `-1` if the initial memory size is
+  undefined.
+* `usi.jvm.memory.heap.used.gauge.bytes` - the amount of used heap
+  memory in bytes.
+* `usi.jvm.memory.heap.max.gauge.bytes` - the maximum amount of
+  heap memory in bytes that can be used for memory management, `-1` if
+  the maximum memory size is undefined.
+* `usi.jvm.memory.heap.committed.gauge.bytes` - the amount of heap
+  memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.heap.usage.gauge` - the ratio of
+  `usi.jvm.memory.heap.used.gauge.bytes` and
+  `usi.jvm.memory.heap.max.gauge.bytes`.
+* `usi.jvm.memory.non-heap.init.gauge.bytes` - the amount of
+  non-heap memory in bytes that the JVM initially requests from the
+  operating system for memory management, or `-1` if the initial memory
+  size is undefined.
+* `usi.jvm.memory.non-heap.used.gauge.bytes` - the amount of used
+  non-heap memory in bytes.
+* `usi.jvm.memory.non-heap.max.gauge.bytes` - the maximum amount of
+  non-heap memory in bytes that can be used for memory management, `-1`
+  if the maximum memory size is undefined.
+* `usi.jvm.memory.non-heap.committed.gauge.bytes` - the amount of
+  non-heap memory in bytes that is committed for the JVM to use.
+* `usi.jvm.memory.non-heap.usage.gauge` - the ratio of
+  `usi.jvm.memory.non-heap.used.gauge.bytes` and
+  `usi.jvm.memory.non-heap.max.gauge.bytes`.
+
+#### JVM threads
+
+* `usi.jvm.threads.active.gauge` — the number of active threads.
+* `usi.jvm.threads.daemon.gauge` — the number of daemon threads.
+* `usi.jvm.threads.deadlocked.gauge` — the number of deadlocked
+  threads.
+* `usi.jvm.threads.new.gauge` — the number of threads in `NEW`
+   state.
+* `usi.jvm.threads.runnable.gauge` — the number of threads in
+  `RUNNABLE` state.
+* `usi.jvm.threads.blocked.gauge` — the number of threads in
+  `BLOCKED` state.
+* `usi.jvm.threads.timed-waiting.gauge` — the number of threads in
+  `TIMED_WAITING` state.
+* `usi.jvm.threads.waiting.gauge` — the number of threads in
+  `WAITING` state.
+* `usi.jvm.threads.terminated.gauge` — the number of threads in
+  `TERMINATED` state.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,7 +1,7 @@
 # Metrics
 
 This module defines a set of metrics interfaces. For a concrete implementation 
-see [metrics-dropwizar](http://github.com/mesosphere/use/metrics-dropwizard) 
+see [metrics-dropwizard](http://github.com/mesosphere/usi/metrics-dropwizard) 
 module. 
 
 ## Metric types

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,27 +1,23 @@
 # Metrics
 
-This is a [Dropwizard Metrics](https://github.com/dropwizard/metrics) implementation 
-of the USI metrics interface. It supports multiple exporters ([DataDog(https://www.datadoghq.com/)],
-[StatsD](https://github.com/etsy/statsd)) as well as text representation in 
-[Prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) format.
+This module defines a set of metrics interfaces. For a concrete implementation 
+see [metrics-dropwizar](http://github.com/mesosphere/use/metrics-dropwizard) 
+module. 
 
 ## Metric types
 
 USI has the following metric types:
 
 * a `counter` is a monotonically increasing integer, for instance, the
-  number of Mesos `revive` calls performed since Marathon became
+  number of Mesos `revive` calls performed since the framework became
   a leader.
-* a `gauge` is a current measurement, for instance, the number of apps
-  currently known to Marathon.
+* a `gauge` is a current measurement, for instance, the number of tasks
+  currently known to the framework.
 * a `histogram` is a distribution of values in a stream of measurements,
   for instance, the number of apps in group deployments.
 * a `meter` measures the rate at which a set of events occur.
 * a `timer` is a combination of a meter and a histogram, which measure
   the duration of events and the rate of their occurrence.
-
-Histograms and timers are backed with reservoirs leveraging
-[HdrHistogram](http://hdrhistogram.org/).
 
 ## Units of measurement
 
@@ -30,134 +26,3 @@ following units:
 
 * `bytes`
 * `seconds`
-
-## Metric names
-
-All metric names are prefixed with `usi` by default. This can be changed
-using `metrics_name_prefix` configuration parameter. Metric name components 
-are joined with dots. Components may have dashes in them.
-
-A metric type and a unit of measurement (if any) are appended to
-a metric name. A couple of examples:
-
-* `usi.scheduler.offers.counter`
-* `usi.scheduler.offers.processing-time.seconds`
-
-## Prometheus reporter
-
-The Prometheus reporter can be used to return a text representation of 
-current metrics and their values. Dots and dashes in metric names are 
-replaced with underscores.
-
-## StatsD reporter
-
-The StatsD reporter can be enabled with `metrics_statsd` parameter. 
-It sends metrics over UDP to the host and port specified with
-`metrics_statsd_host` and `metrics_statsd_port` respectively.
-
-Counters are forwarded as gauges.
-
-## DataDog reporter
-
-The DataDog reporter can be enabled with `metrics_datadog` parameter. 
-It sends metrics over UDP to the host and port specified with `metrics_datadog_host` 
-and `metrics_datadog_port` respectively.
-
-Metrics can be sent to a DataDog agent over UDP, or directly to
-the DataDog cloud over HTTP. It is specified using
-`metrics_datadog_protocol`. Its possible values are `udp` (default)
-and `api`. If `api` is chosen, your DataDog API key can be supplied with
-`metrics_datadog_api_key`.
-
-Dashes in metric names are replaced with underscores. Counters are
-forwarded as gauges.
-
-
-### JVM-specific metrics
-A selected set of JVM related metrics is collected by default.
-
-#### JVM buffer pools
-
-* `usi.jvm.buffers.mapped.gauge` — an estimate of the number of
-  mapped buffers.
-* `usi.jvm.buffers.mapped.capacity.gauge.bytes` — an estimate of
-  the total capacity of the mapped buffers in bytes.
-* `usi.jvm.buffers.mapped.memory.used.gauge.bytes` an estimate of
-  the memory that the JVM is using for mapped buffers in bytes, or `-1L`
-  if an estimate of the memory usage is not available.
-* `usi.jvm.buffers.direct.gauge` — an estimate of the number of
-  direct buffers.
-* `usi.jvm.buffers.direct.capacity.gauge.bytes` — an estimate of
-  the total capacity of the direct buffers in bytes.
-* `usi.jvm.buffers.direct.memory.used.gauge.bytes` an estimate of
-  the memory that the JVM is using for direct buffers in bytes, or `-1L`
-  if an estimate of the memory usage is not available.
-
-#### JVM garbage collection
-
-* `usi.jvm.gc.<gc>.collections.gauge` — the total number
-  of collections that have occurred
-* `usi.jvm.gc.<gc>.collections.duraration.gauge.seconds` — the
-  approximate accumulated collection elapsed time, or `-1` if the
-  collection elapsed time is undefined for the given collector.
-
-#### JVM memory
-
-* `usi.jvm.memory.total.init.gauge.bytes` - the amount of memory
-  in bytes that the JVM initially requests from the operating system
-  for memory management, or `-1` if the initial memory size is
-  undefined.
-* `usi.jvm.memory.total.used.gauge.bytes` - the amount of used
-  memory in bytes.
-* `usi.jvm.memory.total.max.gauge.bytes` - the maximum amount of
-  memory in bytes that can be used for memory management, `-1` if the
-  maximum memory size is undefined.
-* `usi.jvm.memory.total.committed.gauge.bytes` - the amount of
-  memory in bytes that is committed for the JVM to use.
-* `usi.jvm.memory.heap.init.gauge.bytes` - the amount of heap
-  memory in bytes that the JVM initially requests from the operating
-  system for memory management, or `-1` if the initial memory size is
-  undefined.
-* `usi.jvm.memory.heap.used.gauge.bytes` - the amount of used heap
-  memory in bytes.
-* `usi.jvm.memory.heap.max.gauge.bytes` - the maximum amount of
-  heap memory in bytes that can be used for memory management, `-1` if
-  the maximum memory size is undefined.
-* `usi.jvm.memory.heap.committed.gauge.bytes` - the amount of heap
-  memory in bytes that is committed for the JVM to use.
-* `usi.jvm.memory.heap.usage.gauge` - the ratio of
-  `usi.jvm.memory.heap.used.gauge.bytes` and
-  `usi.jvm.memory.heap.max.gauge.bytes`.
-* `usi.jvm.memory.non-heap.init.gauge.bytes` - the amount of
-  non-heap memory in bytes that the JVM initially requests from the
-  operating system for memory management, or `-1` if the initial memory
-  size is undefined.
-* `usi.jvm.memory.non-heap.used.gauge.bytes` - the amount of used
-  non-heap memory in bytes.
-* `usi.jvm.memory.non-heap.max.gauge.bytes` - the maximum amount of
-  non-heap memory in bytes that can be used for memory management, `-1`
-  if the maximum memory size is undefined.
-* `usi.jvm.memory.non-heap.committed.gauge.bytes` - the amount of
-  non-heap memory in bytes that is committed for the JVM to use.
-* `usi.jvm.memory.non-heap.usage.gauge` - the ratio of
-  `usi.jvm.memory.non-heap.used.gauge.bytes` and
-  `usi.jvm.memory.non-heap.max.gauge.bytes`.
-
-#### JVM threads
-
-* `usi.jvm.threads.active.gauge` — the number of active threads.
-* `usi.jvm.threads.daemon.gauge` — the number of daemon threads.
-* `usi.jvm.threads.deadlocked.gauge` — the number of deadlocked
-  threads.
-* `usi.jvm.threads.new.gauge` — the number of threads in `NEW`
-   state.
-* `usi.jvm.threads.runnable.gauge` — the number of threads in
-  `RUNNABLE` state.
-* `usi.jvm.threads.blocked.gauge` — the number of threads in
-  `BLOCKED` state.
-* `usi.jvm.threads.timed-waiting.gauge` — the number of threads in
-  `TIMED_WAITING` state.
-* `usi.jvm.threads.waiting.gauge` — the number of threads in
-  `WAITING` state.
-* `usi.jvm.threads.terminated.gauge` — the number of threads in
-  `TERMINATED` state.

--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'scala'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile group: 'com.typesafe.akka', name: 'akka-stream_2.12', version: '2.5.19'
+}
+

--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -1,11 +1,3 @@
-plugins {
-    id 'scala'
-}
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile group: 'com.typesafe.akka', name: 'akka-stream_2.12', version: '2.5.19'
 }

--- a/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
+++ b/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
@@ -1,0 +1,59 @@
+package com.mesosphere.usi.metrics
+
+import java.time.Clock
+import akka.stream.scaladsl.Source
+import scala.concurrent.Future
+
+trait Metric
+
+trait Counter extends Metric {
+  def increment(): Unit
+  def increment(times: Long): Unit
+}
+
+trait Gauge extends Metric {
+  def value(): Long
+  def increment(by: Long = 1): Unit
+  def decrement(by: Long = 1): Unit
+}
+
+trait SettableGauge extends Gauge {
+  def setValue(value: Long): Unit
+}
+
+trait ClosureGauge extends Metric
+
+trait MinMaxCounter extends Metric {
+  def increment(): Unit
+  def increment(times: Long): Unit
+  def decrement(): Unit
+  def decrement(times: Long): Unit
+}
+
+trait Meter extends Metric {
+  def mark(): Unit
+}
+
+trait TimerAdapter extends Metric {
+  def update(value: Long): Unit
+}
+
+trait Timer extends TimerAdapter {
+  def apply[T](f: => Future[T]): Future[T]
+  def forSource[T, M](f: => Source[T, M])(implicit clock: Clock = Clock.systemUTC): Source[T, M]
+  def blocking[T](f: => T): T
+
+  // value is in nanoseconds
+  def update(value: Long): Unit
+}
+
+trait Metrics {
+  def counter(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Counter
+  def gauge(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Gauge
+  def closureGauge[N](name: String, currentValue: () => N,
+                      unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge
+  def settableGauge(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): SettableGauge
+  def meter(name: String): Meter
+  def timer(name: String): Timer
+}
+

--- a/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
+++ b/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
@@ -4,32 +4,42 @@ import java.time.Clock
 import akka.stream.scaladsl.Source
 import scala.concurrent.Future
 
+/**
+  * Basic trait for all metric types
+  */
 trait Metric
 
-trait Counter extends Metric {
-  def increment(): Unit
-  def increment(times: Long): Unit
-}
-
+/**
+  * A gauge is an instantaneous measurement of a value e.g. number of offer processed.
+  */
 trait Gauge extends Metric {
   def value(): Long
   def increment(by: Long = 1): Unit
   def decrement(by: Long = 1): Unit
 }
 
+/**
+  * A counter is just a gauge for an [[java.util.concurrent.atomic.AtomicLong]] instance. You can increment or decrement
+  * its value.
+  */
+trait Counter extends Metric {
+  def increment(): Unit
+  def increment(times: Long): Unit
+}
+
+/**
+  * A settable gauge is like the usual [[Gauge]] but you can also set it's value directly.
+  */
 trait SettableGauge extends Gauge {
   def setValue(value: Long): Unit
 }
 
 trait ClosureGauge extends Metric
 
-trait MinMaxCounter extends Metric {
-  def increment(): Unit
-  def increment(times: Long): Unit
-  def decrement(): Unit
-  def decrement(times: Long): Unit
-}
-
+/**
+  * A meter metric which measures mean throughput and one-, five-, and fifteen-minute exponentially-weighted moving
+  * average throughput.
+  */
 trait Meter extends Metric {
   def mark(): Unit
 }
@@ -38,6 +48,9 @@ trait TimerAdapter extends Metric {
   def update(value: Long): Unit
 }
 
+/**
+  * A timer measures both the rate that a particular piece of code is called and the distribution of its duration.
+  */
 trait Timer extends TimerAdapter {
   def apply[T](f: => Future[T]): Future[T]
   def forSource[T, M](f: => Source[T, M])(implicit clock: Clock = Clock.systemUTC): Source[T, M]

--- a/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
+++ b/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
@@ -10,7 +10,8 @@ import scala.concurrent.Future
 trait Metric
 
 /**
-  * A gauge is an instantaneous measurement of a value e.g. number of offer processed.
+  * A gauge is an instantaneous measurement of a value e.g. number of offer processed. You can increment and
+  * decrement it's value.
   */
 trait Gauge extends Metric {
   def value(): Long
@@ -19,8 +20,8 @@ trait Gauge extends Metric {
 }
 
 /**
-  * A counter is just a gauge for an [[java.util.concurrent.atomic.AtomicLong]] instance. You can increment or decrement
-  * its value.
+  * A counter is just a gauge for an [[java.util.concurrent.atomic.AtomicLong]] instance. Note that you can only
+  * increment it's value.
   */
 trait Counter extends Metric {
   def increment(): Unit
@@ -34,11 +35,14 @@ trait SettableGauge extends Gauge {
   def setValue(value: Long): Unit
 }
 
+/**
+  * A closer gauge is a special sort of gauge where a lambda can be passed which will be called,
+  * each time, the gauges value is fetched.
+  */
 trait ClosureGauge extends Metric
 
 /**
-  * A meter metric which measures mean throughput and one-, five-, and fifteen-minute exponentially-weighted moving
-  * average throughput.
+  * A meter measures the rate at which a set of events occur.
   */
 trait Meter extends Metric {
   def mark(): Unit
@@ -57,7 +61,7 @@ trait Timer extends TimerAdapter {
   def blocking[T](f: => T): T
 
   // value is in nanoseconds
-  def update(value: Long): Unit
+  override def update(value: Long): Unit
 }
 
 trait Metrics {

--- a/metrics/src/main/scala/com/mesosphere/usi/metrics/UnitOfMeasurement.scala
+++ b/metrics/src/main/scala/com/mesosphere/usi/metrics/UnitOfMeasurement.scala
@@ -1,0 +1,21 @@
+package com.mesosphere.usi.metrics
+
+sealed trait UnitOfMeasurement
+
+object UnitOfMeasurement {
+
+  /**
+    * Default unit of measurement. Not suffix is appended to metric names.
+    */
+  case object None extends UnitOfMeasurement
+
+  /**
+    * Memory is measure in bytes. ".bytes" is appended to metric names.
+    */
+  case object Memory extends UnitOfMeasurement
+
+  /**
+    * Time is measured in seconds. ".seconds" is appended to timer names.
+    */
+  case object Time extends UnitOfMeasurement
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,10 @@ rootProject.name = 'usi'
 
 include 'interfaces'
 include 'core'
+include 'metrics'
+findProject(':metrics')?.name = 'usi-metrics'
+include 'metrics-dropwizard'
+findProject(':metrics-dropwizard')?.name = 'usi-metrics-dropwizard'
 
 /* example projects*/
 include 'hello-world'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,9 +3,7 @@ rootProject.name = 'usi'
 include 'interfaces'
 include 'core'
 include 'metrics'
-findProject(':metrics')?.name = 'usi-metrics'
 include 'metrics-dropwizard'
-findProject(':metrics-dropwizard')?.name = 'usi-metrics-dropwizard'
 
 /* example projects*/
 include 'hello-world'


### PR DESCRIPTION
Summary:
Ported Marathon's metrics interface and it's Dropwizard implementation:
- `metrics` contains a common interface for metrics implementation. It defines a common `Metrics` interface as well as a set of interfaces for common metrics primitives like `Counter`, `Gauge` etc.
- `metrics-dropwizard` contains Dropwizard metrics implementation
- Additionally ported Marathon's metrics reporter: StatsD, DataDog (API and UDP) and Prometheus

JIRA: DCOS-47507


Co-authored-by: Ivan Chernetsky <ichernetsky@mesosphere.io>