### PR TITLE
Rename `mesos-client` configuration parameters

### DIFF
--- a/mesos-client/examples/com/mesosphere/mesos/examples/UselessFramework.scala
+++ b/mesos-client/examples/com/mesosphere/mesos/examples/UselessFramework.scala
@@ -31,19 +31,19 @@ object UselessFramework extends App with StrictLoggingFlow {
 
   val frameworkInfo = FrameworkInfo.newBuilder()
     .setUser("foo")
-    .setName("Example FOO Framework")
+    .setName("Useless Framework")
     .setId(FrameworkID.newBuilder.setValue(UUID.randomUUID().toString))
     .addRoles("test")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .build()
 
-  val conf = MesosClientSettings(ConfigFactory.load())
+  val conf = MesosClientSettings(ConfigFactory.load().getConfig("mesos-client"))
   val client = Await.result(MesosClient(conf, frameworkInfo).runWith(Sink.head), 10.seconds)
 
   client.mesosSource.runWith(Sink.foreach { event =>
 
     if (event.getType == Event.Type.SUBSCRIBED) {
-      logger.info("Successfully subscribed to mesos")
+      logger.info("Successfully subscribed to Mesos")
     } else if (event.getType == Event.Type.OFFERS) {
 
       val offerIds = event.getOffers.getOffersList.asScala.map(_.getId).toList

--- a/mesos-client/src/main/resources/reference.conf
+++ b/mesos-client/src/main/resources/reference.conf
@@ -1,13 +1,17 @@
-connection {
-  masterUrl: "127.0.0.1:5050"
+mesos-client {
+
+  // mesos master host:port
+  master-url: "127.0.0.1:5050"
+
   // number of retries to follow mesos master redirect
-  redirectRetries: 3
+  redirect-retries: 3
+
   // Time in seconds between two processed elements exceeds the provided timeout then the connection to mesos
   // is interrupted. Is usually set to approx. 5 hear beats.
-  idleTimeout: "75 seconds"
-}
+  idle-timeout: "75 seconds"
 
-backPressure {
-  // number of messages coming from Mesos that can be queued before we start droping them as a backpressure mechanism
-  sourceBufferSize: 10
+  back-pressure {
+    // number of messages coming from Mesos that can be queued before we start droping them as a backpressure mechanism
+    source-buffer-size: 10
+  }
 }

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
@@ -5,10 +5,10 @@ import com.typesafe.config.Config
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 case class MesosClientSettings(conf: Config) {
-  val master: String = conf.getString("connection.masterUrl")
-  val redirectRetries: Int = conf.getInt("connection.redirectRetries")
+  val master: String = conf.getString("master-url")
+  val redirectRetries: Int = conf.getInt("redirect-retries")
   // we want FiniteDuration, the conversion is needed to achieve that
-  val idleTimeout: FiniteDuration = Duration.fromNanos(conf.getDuration("connection.idleTimeout").toNanos)
+  val idleTimeout: FiniteDuration = Duration.fromNanos(conf.getDuration("idle-timeout").toNanos)
 
-  val sourceBufferSize: Int = conf.getInt("backPressure.sourceBufferSize")
+  val sourceBufferSize: Int = conf.getInt("back-pressure.source-buffer-size")
 }


### PR DESCRIPTION
Summary:
- the standard for config files seems to be the kebab-case
- renamed `connection` to `mesos-client` - the former is too generic and who knows what other connections we might end up with
- `MesosSettings` class gets the `mesos-client.*` part of the config tree. This way we can rename parent/s later