### PR TITLE
 Archive JUnit XML reports. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ allprojects {
 
     test {
         reports.html.enabled = false
+        reports.junitXml.destination = file(Paths.get(rootProject.buildDir.toString(), "tests", project.name))
     }
     check {}
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.129'
+    implementation 'software.amazon.awssdk:s3:2.3.9'
     implementation 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2'
     implementation 'org.scala-lang:scala-library:2.12.7'
     implementation 'org.scalaj:scalaj-http_2.12:2.4.1'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,8 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk:s3:2.3.9'
     implementation 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2'
+    implementation 'commons-io:commons-io:2.6'
     implementation 'org.scala-lang:scala-library:2.12.7'
     implementation 'org.scalaj:scalaj-http_2.12:2.4.1'
+    implementation 'software.amazon.awssdk:s3:2.3.9'
 }

--- a/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
+++ b/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
@@ -14,16 +14,38 @@ import software.amazon.awssdk.services.s3.model.{PutObjectRequest, PutObjectResp
 
 import scala.beans.BeanProperty
 
+/**
+  * The S3Upload task defines a basic uploader for AWS S3.
+  */
 class S3Upload extends DefaultTask with StrictLogging {
 
   lazy val s3: S3AsyncClient = S3AsyncClient.builder().region(Region.of(region)).build()
 
+  /**
+    * Defines the AWS region. Defaults to us-west-2.
+    */
   @BeanProperty var region: String = "us-west-2"
 
+  /**
+    * The bucket name for all uploaded objects.
+    */
   @BeanProperty var bucket: String = ""
 
+  /**
+    * The prefix used for all files to create the key. The S3 object key will be "$prefix/$filePath"
+    *
+    * Example:
+    *
+    * Given the prefix is "foo/bar"
+    * And we have a file "build/tests/failed.xml"
+    * And source points to "build/"
+    * Then the object key for "failed.xml" will be "foo/bar/tests/failed.xml"
+    */
   @BeanProperty var prefix: String = ""
 
+  /**
+    * Defines the root with filters for all files that should be uploaded to [[bucket]].
+    */
   @BeanProperty var source: FileTree = null
 
   @TaskAction
@@ -54,6 +76,9 @@ class S3Upload extends DefaultTask with StrictLogging {
 
 }
 
+/**
+  * Defines a mapping from file extensions to MIME types, ie Content-type metadata.
+  */
 object ContentType {
   val contentTypeMap = Map(
     "html" -> "text/html",

--- a/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
+++ b/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
@@ -34,7 +34,7 @@ class S3Upload extends DefaultTask with StrictLogging {
       if (!fileDetails.isDirectory) {
         val file = fileDetails.getRelativePath()
         val key = s"$prefix/$file"
-        val request = PutObjectRequest.builder().bucket(bucket).key(key).contentType("test/plain").build()
+        val request = PutObjectRequest.builder().bucket(bucket).key(key).contentType("test/html").build()
         val body = AsyncRequestBody.fromFile(fileDetails.getFile)
         pendingUploads = pendingUploads :+ s3.putObject(request, body)
       }

--- a/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
+++ b/buildSrc/src/main/scala/mesosphere/gradle/aws/S3Upload.scala
@@ -34,7 +34,7 @@ class S3Upload extends DefaultTask with StrictLogging {
       if (!fileDetails.isDirectory) {
         val file = fileDetails.getRelativePath()
         val key = s"$prefix/$file"
-        val request = PutObjectRequest.builder().bucket(bucket).key(key).build()
+        val request = PutObjectRequest.builder().bucket(bucket).key(key).contentType("test/plain").build()
         val body = AsyncRequestBody.fromFile(fileDetails.getFile)
         pendingUploads = pendingUploads :+ s3.putObject(request, body)
       }

--- a/ci.gradle
+++ b/ci.gradle
@@ -6,7 +6,7 @@ task testReport(type: TestReport) {
     description = "Aggregate all test results from subprojects into one test report."
     group = "CI"
 
-    destinationDir = file("$buildDir/reports/allTests")
+    destinationDir = file("$buildDir/reports/tests")
     // Include the results from the `test` task in all subprojects
     reportOn subprojects*.test
     dependsOn(subprojects.check)
@@ -24,7 +24,10 @@ task uploadTestReports(type: S3Upload) {
     region = "us-west-2"
     bucket = "usi-builds"
     prefix = "$repoSlug/$branch/$buildNumber"
-    source = testReport.destinationDir
+    source = fileTree(rootProject.buildDir) {
+        include 'reports/tests/**'
+        include 'tests/**'
+    }
 }
 
 task githubReport(type: GithubStatus) {
@@ -36,7 +39,7 @@ task githubReport(type: GithubStatus) {
     commit = TravisEnvironment.commit()
     context = "mesosphere/tests"
     statusDescription = "Test results"
-    targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/index.html"
+    targetUrl = "https://s3-us-west-2.amazonaws.com/${uploadTestReports.bucket}/${uploadTestReports.prefix}/reports/tests/index.html"
 }
 
 gitPublish {

--- a/ci.gradle
+++ b/ci.gradle
@@ -6,7 +6,7 @@ task testReport(type: TestReport) {
     description = "Aggregate all test results from subprojects into one test report."
     group = "CI"
 
-    destinationDir = file("$buildDir/reports/tests")
+    destinationDir = file("${rootProject.buildDir}/reports/tests")
     // Include the results from the `test` task in all subprojects
     reportOn subprojects*.test
     dependsOn(subprojects.check)
@@ -25,8 +25,8 @@ task uploadTestReports(type: S3Upload) {
     bucket = "usi-builds"
     prefix = "$repoSlug/$branch/$buildNumber"
     source = fileTree(rootProject.buildDir) {
-        include 'reports/tests/**'
-        include 'tests/**'
+        include 'reports/tests/**' // All test HTML reports aggregated by testReport.
+        include 'tests/**'         // All test JUnit XML files saved to ./build/tests. See allprojects.test { ... }.
     }
 }
 


### PR DESCRIPTION
Summary:
This will upload the JUnit test reports alongside the HTML reports. The folder structure changes a little but on S3. The human readable reports will be in `<owner>/<repo>/<branch>/<build>/reports/tests` and the JUnit files in `<owner>/<repo>/<branch>/<build>/tests`.

This patch will also migrate the S3 upload task to the AWS SDK 2.3.x and uses an asynchronous upload client.

JIRA issue: DCOS-47520