### PR TITLE
Scalafmt from one config, more formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,3 @@
 maxColumn = 120
 includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
 align = none

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import java.nio.file.Paths
 plugins {
     id 'idea'
     id 'org.ajoberstar.git-publish' version '2.0.0'
-    id 'cz.alenkacz.gradle.scalafmt' version '1.7.0'
+    id 'cz.alenkacz.gradle.scalafmt' version '1.7.2'
 }
 
 ext {
@@ -19,6 +19,7 @@ allprojects {
     version = '0.1'
 
     apply plugin: "scala"
+    apply plugin: 'cz.alenkacz.gradle.scalafmt'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/core-models/.scalafmt.conf
+++ b/core-models/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/core/.scalafmt.conf
+++ b/core/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/examples/hello-world/.scalafmt.conf
+++ b/examples/hello-world/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/examples/mesos-client-example/.scalafmt.conf
+++ b/examples/mesos-client-example/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/examples/mesos-client-example/src/main/scala/com/mesosphere/mesos/examples/MesosClientExampleFramework.scala
+++ b/examples/mesos-client-example/src/main/scala/com/mesosphere/mesos/examples/MesosClientExampleFramework.scala
@@ -30,12 +30,14 @@ object MesosClientExampleFramework extends App with StrictLoggingFlow {
   implicit val materializer = ActorMaterializer()
   implicit val executionContext = system.dispatcher
 
-  val frameworkInfo = FrameworkInfo.newBuilder()
+  val frameworkInfo = FrameworkInfo
+    .newBuilder()
     .setUser("mesos-client")
     .setName("MesosClientExample")
     .setId(FrameworkID.newBuilder.setValue(UUID.randomUUID().toString))
     .addRoles("test")
-    .addCapabilities(FrameworkInfo.Capability.newBuilder()
+    .addCapabilities(FrameworkInfo.Capability
+      .newBuilder()
       .setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .build()
 

--- a/mesos-client/.scalafmt.conf
+++ b/mesos-client/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosCalls.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosCalls.scala
@@ -25,7 +25,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#teardown
     */
   def newTeardown(): Call = {
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.TEARDOWN)
       .setFrameworkId(frameworkId)
       .build()
@@ -42,7 +43,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
     */
   def newAccept(accepts: Accept): Call = {
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.ACCEPT)
       .setFrameworkId(frameworkId)
       .setAccept(accepts)
@@ -62,7 +64,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     offerIds.foreach(declineBuilder.addOfferIds)
     filters.foreach(declineBuilder.setFilters)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.DECLINE)
       .setFrameworkId(frameworkId)
       .setDecline(declineBuilder.build())
@@ -80,7 +83,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     val reviveBuilder = Revive.newBuilder()
     role.foreach(reviveBuilder.addRoles)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.REVIVE)
       .setFrameworkId(frameworkId)
       .setRevive(reviveBuilder.build())
@@ -99,7 +103,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     val suppressBuilder = Call.Suppress.newBuilder()
     role.foreach(suppressBuilder.addRoles)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.SUPPRESS)
       .setFrameworkId(frameworkId)
       .setSuppress(suppressBuilder)
@@ -120,12 +125,14 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#kill
     */
   def newKill(taskId: TaskID, agentId: Option[AgentID] = None, killPolicy: Option[KillPolicy]): Call = {
-    val killBuilder = Call.Kill.newBuilder()
+    val killBuilder = Call.Kill
+      .newBuilder()
       .setTaskId(taskId)
     agentId.foreach(killBuilder.setAgentId)
     killPolicy.foreach(killBuilder.setKillPolicy)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.KILL)
       .setFrameworkId(frameworkId)
       .setKill(killBuilder)
@@ -141,11 +148,13 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#shutdown
     */
   def newShutdown(executorId: ExecutorID, agentId: AgentID): Call = {
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.SHUTDOWN)
       .setFrameworkId(frameworkId)
       .setShutdown(
-        Call.Shutdown.newBuilder()
+        Call.Shutdown
+          .newBuilder()
           .setExecutorId(executorId)
           .setAgentId(agentId)
           .build())
@@ -163,11 +172,13 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#acknowledge
     */
   def newAcknowledge(agentId: AgentID, taskId: TaskID, uuid: protobuf.ByteString): Call = {
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.ACKNOWLEDGE)
       .setFrameworkId(frameworkId)
       .setAcknowledge(
-        Call.Acknowledge.newBuilder()
+        Call.Acknowledge
+          .newBuilder()
           .setAgentId(agentId)
           .setTaskId(taskId)
           .setUuid(uuid)
@@ -188,7 +199,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     val reconcileBuilder = Call.Reconcile.newBuilder()
     tasks.foreach(reconcileBuilder.addTasks)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.RECONCILE)
       .setFrameworkId(frameworkId)
       .setReconcile(reconcileBuilder)
@@ -204,11 +216,13 @@ class MesosCalls(frameworkId: FrameworkID) {
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#message
     */
   def newMessage(agentId: AgentID, executorId: ExecutorID, message: ByteString): Call = {
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.MESSAGE)
       .setFrameworkId(frameworkId)
       .setMessage(
-        Call.Message.newBuilder()
+        Call.Message
+          .newBuilder()
           .setAgentId(agentId)
           .setExecutorId(executorId)
           .setData(protobuf.ByteString.copyFrom(message.toArray))
@@ -228,7 +242,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     val requestBuilder = Call.Request.newBuilder()
     requests.foreach(requestBuilder.addRequests)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.REQUEST)
       .setFrameworkId(frameworkId)
       .setRequest(requestBuilder)
@@ -248,7 +263,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     offers.foreach(acceptInverseBuilder.addInverseOfferIds)
     filters.foreach(acceptInverseBuilder.setFilters)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.ACCEPT_INVERSE_OFFERS)
       .setFrameworkId(frameworkId)
       .setAcceptInverseOffers(acceptInverseBuilder)
@@ -269,7 +285,8 @@ class MesosCalls(frameworkId: FrameworkID) {
     offers.foreach(declineInverseBuilder.addInverseOfferIds)
     filters.foreach(declineInverseBuilder.setFilters)
 
-    Call.newBuilder()
+    Call
+      .newBuilder()
       .setType(Call.Type.DECLINE_INVERSE_OFFERS)
       .setFrameworkId(frameworkId)
       .setDeclineInverseOffers(declineInverseBuilder)

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
@@ -8,7 +8,8 @@ case class MesosClientSettings(conf: Config) {
   val master: String = conf.getString("master-url")
   val redirectRetries: Int = conf.getInt("redirect-retries")
   // we want FiniteDuration, the conversion is needed to achieve that
-  val idleTimeout: FiniteDuration = Duration.fromNanos(conf.getDuration("MesosClientSettings").toNanos)
+  val idleTimeout: FiniteDuration =
+    Duration.fromNanos(conf.getDuration("MesosClientSettings").toNanos)
 
   val sourceBufferSize: Int = conf.getInt("back-pressure.source-buffer-size")
 }

--- a/metrics-dropwizard/.scalafmt.conf
+++ b/metrics-dropwizard/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetrics.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetrics.scala
@@ -9,7 +9,17 @@ import com.codahale.metrics
 import com.codahale.metrics.MetricRegistry
 import com.github.rollingmetrics.histogram.{HdrBuilder, OverflowResolver}
 import com.mesosphere.usi.metrics.dropwizard.conf.MetricsSettings
-import com.mesosphere.usi.metrics.{ClosureGauge, Counter, Gauge, Meter, Metrics, SettableGauge, Timer, TimerAdapter, UnitOfMeasurement} //format:OFF
+import com.mesosphere.usi.metrics.{
+  ClosureGauge,
+  Counter,
+  Gauge,
+  Meter,
+  Metrics,
+  SettableGauge,
+  Timer,
+  TimerAdapter,
+  UnitOfMeasurement
+}
 
 import scala.util.matching.Regex
 
@@ -21,7 +31,8 @@ class DropwizardMetrics(metricsSettings: MetricsSettings, registry: MetricRegist
   private val histogramReservoirHighestTrackableValue = histrogramSettings.reservoirHighestTrackableValue
   private val histogramReservoirSignificantDigits = histrogramSettings.reservoirSignificantDigits
   private val histogramReservoirResetPeriodically = histrogramSettings.reservoirResetPeriodically
-  private val histogramReservoirResettingInterval = Duration.ofNanos(histrogramSettings.reservoirResettingInterval.toNanos)
+  private val histogramReservoirResettingInterval =
+    Duration.ofNanos(histrogramSettings.reservoirResettingInterval.toNanos)
   private val histogramReservoirResettingChunks = histrogramSettings.reservoirResettingChunks
 
   implicit class DropwizardCounter(val counter: codahale.metrics.Counter) extends Counter {
@@ -32,9 +43,10 @@ class DropwizardMetrics(metricsSettings: MetricsSettings, registry: MetricRegist
     registry.counter(constructName(namePrefix, name, "counter", unit))
   }
 
-  override def closureGauge[N](name: String,
-                               fn: () => N,
-                               unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge = {
+  override def closureGauge[N](
+      name: String,
+      fn: () => N,
+      unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge = {
     class DropwizardClosureGauge(val name: String) extends ClosureGauge {
       registry.gauge(name, () => () => fn())
     }
@@ -77,14 +89,16 @@ class DropwizardMetrics(metricsSettings: MetricsSettings, registry: MetricRegist
       val reservoirBuilder = new HdrBuilder()
         .withSignificantDigits(histogramReservoirSignificantDigits)
         .withLowestDiscernibleValue(1)
-        .withHighestTrackableValue(histogramReservoirHighestTrackableValue,
-                                   OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
+        .withHighestTrackableValue(
+          histogramReservoirHighestTrackableValue,
+          OverflowResolver.REDUCE_TO_HIGHEST_TRACKABLE)
       if (histogramReservoirResetPeriodically) {
         if (histogramReservoirResettingChunks == 0)
           reservoirBuilder.resetReservoirPeriodically(histogramReservoirResettingInterval)
         else
-          reservoirBuilder.resetReservoirPeriodicallyByChunks(histogramReservoirResettingInterval,
-                                                              histogramReservoirResettingChunks)
+          reservoirBuilder.resetReservoirPeriodicallyByChunks(
+            histogramReservoirResettingInterval,
+            histogramReservoirResettingChunks)
       }
       val reservoir = reservoirBuilder.buildReservoir()
       new metrics.Timer(reservoir)
@@ -99,8 +113,8 @@ object DropwizardMetrics {
 
   def constructName(prefix: String, name: String, `type`: String, unit: UnitOfMeasurement): String = {
     val unitSuffix = unit match {
-      case UnitOfMeasurement.None   => ""
-      case UnitOfMeasurement.Time   => ".seconds"
+      case UnitOfMeasurement.None => ""
+      case UnitOfMeasurement.Time => ".seconds"
       case UnitOfMeasurement.Memory => ".bytes"
     }
     val constructedName = s"$prefix.$name.${`type`}$unitSuffix"

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsModule.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/DropwizardMetricsModule.scala
@@ -6,7 +6,11 @@ import akka.Done
 import akka.actor.ActorRefFactory
 import com.codahale.metrics.MetricRegistry
 import com.mesosphere.usi.metrics.Metrics
-import com.mesosphere.usi.metrics.dropwizard.conf.{DataDogApiReporterSettings, DataDogUdpReporterSettings, MetricsSettings} //format:OFF
+import com.mesosphere.usi.metrics.dropwizard.conf.{
+  DataDogApiReporterSettings,
+  DataDogUdpReporterSettings,
+  MetricsSettings
+}
 import com.mesosphere.usi.metrics.dropwizard.reporters.{DataDogAPIReporter, DataDogUDPReporter, StatsDReporter}
 import com.typesafe.config.Config
 

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettings.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/conf/MetricsSettings.scala
@@ -6,17 +6,20 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import net.ceedubs.ficus.Ficus.{finiteDurationReader, toFicusConfig}
 
-case class HistorgramSettings(reservoirHighestTrackableValue: Long = 3600000000000L,
-                              reservoirSignificantDigits: Int = 3,
-                              reservoirResetPeriodically: Boolean = true,
-                              reservoirResettingInterval: FiniteDuration = 5.seconds,
-                              reservoirResettingChunks: Int = 0) {
+case class HistorgramSettings(
+    reservoirHighestTrackableValue: Long = 3600000000000L,
+    reservoirSignificantDigits: Int = 3,
+    reservoirResetPeriodically: Boolean = true,
+    reservoirResettingInterval: FiniteDuration = 5.seconds,
+    reservoirResettingChunks: Int = 0) {
   require(reservoirHighestTrackableValue > 1L, "reservoir-highest-trackable-value: should be > 1")
-  require(reservoirSignificantDigits >= 0 && reservoirSignificantDigits <= 5,
-          "reservoir-significant-digits should be >= 0 and <= 5")
+  require(
+    reservoirSignificantDigits >= 0 && reservoirSignificantDigits <= 5,
+    "reservoir-significant-digits should be >= 0 and <= 5")
   require(reservoirResettingInterval > Duration.Zero, "reservoir-resetting-interval should be > 0")
-  require(reservoirResettingChunks == 0 || reservoirResettingChunks >= 2,
-          "reservoir-resetting-chunks should be == 0 or >= 2")
+  require(
+    reservoirResettingChunks == 0 || reservoirResettingChunks >= 2,
+    "reservoir-resetting-chunks should be == 0 or >= 2")
 }
 
 object HistorgramSettings {
@@ -77,10 +80,11 @@ object DataDogReporterSettings {
   }
 }
 
-case class MetricsSettings(namePrefix: String,
-                           historgramSettings: HistorgramSettings,
-                           statsdReporterSettings: Option[StatsdReporterSettings],
-                           dataDogReporterSettings: Option[DataDogReporterSettings]) {
+case class MetricsSettings(
+    namePrefix: String,
+    historgramSettings: HistorgramSettings,
+    statsdReporterSettings: Option[StatsdReporterSettings],
+    dataDogReporterSettings: Option[DataDogReporterSettings]) {
   require(namePrefix.nonEmpty, "name-prefix should not be empty")
 }
 

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogAPIReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogAPIReporter.scala
@@ -94,7 +94,7 @@ class DataDogAPIReporter(settings: DataDogApiReporterSettings, registry: MetricR
   private def reportGauge(buffer: StringBuilder, name: String, gauge: Gauge[_], timestamp: Long): Unit = {
     val value: Number = gauge.getValue match {
       case v: Double => if (v.isNaN) 0.0 else v
-      case v: Float  => if (v.isNaN) 0.0 else v.toDouble
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
       case v: Number => v
     }
 
@@ -105,7 +105,8 @@ class DataDogAPIReporter(settings: DataDogApiReporterSettings, registry: MetricR
     reportMetric(buffer, name, counter.getCount.toString, timestamp, "gauge")
 
   private val histogramSnapshotSuffixes =
-    Seq("min",
+    Seq(
+      "min",
       "average",
       "median",
       "75percentile",
@@ -115,11 +116,12 @@ class DataDogAPIReporter(settings: DataDogApiReporterSettings, registry: MetricR
       "999percentile",
       "max",
       "stddev")
-  private def reportSnapshot(buffer: StringBuilder,
-   name: String,
-   snapshot: Snapshot,
-   timestamp: Long,
-   scaleMetrics: Boolean): Unit = {
+  private def reportSnapshot(
+      buffer: StringBuilder,
+      name: String,
+      snapshot: Snapshot,
+      timestamp: Long,
+      scaleMetrics: Boolean): Unit = {
 
     val values = Seq(
       snapshot.getMin.toDouble,
@@ -172,11 +174,12 @@ class DataDogAPIReporter(settings: DataDogApiReporterSettings, registry: MetricR
     reportMetered(buffer, name, timer, timestamp)
   }
 
-  private def reportMetric(buffer: StringBuilder,
-                           name: String,
-                           value: String,
-                           timestamp: Long,
-                           metricType: String): Unit = {
+  private def reportMetric(
+      buffer: StringBuilder,
+      name: String,
+      value: String,
+      timestamp: Long,
+      metricType: String): Unit = {
     if (buffer.length() > 0) buffer.append(',')
     buffer.append(
       s"""{"metric":"$name","interval":$transmissionInterval,"points":[[$timestamp,$value]],"type":"$metricType",host:"$host"}""")

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogUDPReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/DataDogUDPReporter.scala
@@ -41,15 +41,22 @@ class DataDogUDPReporter(settings: DataDogUdpReporterSettings, registry: MetricR
   }
 
   private def report(socket: ActorRef): Unit = {
-    report(socket, registry.getGauges, registry.getCounters, registry.getHistograms, registry.getMeters, registry.getTimers)
+    report(
+      socket,
+      registry.getGauges,
+      registry.getCounters,
+      registry.getHistograms,
+      registry.getMeters,
+      registry.getTimers)
   }
 
-  private def report(socket: ActorRef,
-   gauges: util.SortedMap[String, Gauge[_]],
-   counters: util.SortedMap[String, Counter],
-   histograms: util.SortedMap[String, Histogram],
-   meters: util.SortedMap[String, Meter],
-   timers: util.SortedMap[String, Timer]): Unit = {
+  private def report(
+      socket: ActorRef,
+      gauges: util.SortedMap[String, Gauge[_]],
+      counters: util.SortedMap[String, Counter],
+      histograms: util.SortedMap[String, Histogram],
+      meters: util.SortedMap[String, Meter],
+      timers: util.SortedMap[String, Timer]): Unit = {
 
     gauges.asScala.foreach {
       case (name, value) => reportGauge(socket, sanitizeName(name), value)
@@ -80,7 +87,7 @@ class DataDogUDPReporter(settings: DataDogUdpReporterSettings, registry: MetricR
   private def reportGauge(socket: ActorRef, name: String, gauge: Gauge[_]): Unit = {
     val value: Number = gauge.getValue match {
       case v: Double => if (v.isNaN) 0.0 else v
-      case v: Float  => if (v.isNaN) 0.0 else v.toDouble
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
       case v: Number => v
     }
 
@@ -91,16 +98,17 @@ class DataDogUDPReporter(settings: DataDogUdpReporterSettings, registry: MetricR
     maybeSendAndAppend(socket, s"$name:${counter.getCount}|g\n")
 
   private val histogramSnapshotSuffixes =
-    Seq("min",
-        "average",
-        "median",
-        "75percentile",
-        "95percentile",
-        "98percentile",
-        "99percentile",
-        "999percentile",
-        "max",
-        "stddev")
+    Seq(
+      "min",
+      "average",
+      "median",
+      "75percentile",
+      "95percentile",
+      "98percentile",
+      "99percentile",
+      "999percentile",
+      "max",
+      "stddev")
   private def reportSnapshot(socket: ActorRef, name: String, snapshot: Snapshot, scaleMetrics: Boolean): Unit = {
     val values = Seq(
       snapshot.getMin.toDouble,

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/PrometheusReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/PrometheusReporter.scala
@@ -12,11 +12,12 @@ object PrometheusReporter {
     report(registry.getGauges, registry.getCounters, registry.getHistograms, registry.getMeters, registry.getTimers)
   }
 
-  private def report(gauges: util.SortedMap[String, Gauge[_]],
-                     counters: util.SortedMap[String, Counter],
-                     histograms: util.SortedMap[String, Histogram],
-                     meters: util.SortedMap[String, Meter],
-                     timers: util.SortedMap[String, Timer]): String = {
+  private def report(
+      gauges: util.SortedMap[String, Gauge[_]],
+      counters: util.SortedMap[String, Counter],
+      histograms: util.SortedMap[String, Histogram],
+      meters: util.SortedMap[String, Meter],
+      timers: util.SortedMap[String, Timer]): String = {
 
     val buffer = new StringBuilder
 
@@ -46,7 +47,7 @@ object PrometheusReporter {
   private def reportGauge(buffer: StringBuilder, name: String, gauge: Gauge[_]): Unit = {
     val value: Number = gauge.getValue match {
       case v: Double => if (v.isNaN) 0.0 else v
-      case v: Float  => if (v.isNaN) 0.0 else v.toDouble
+      case v: Float => if (v.isNaN) 0.0 else v.toDouble
       case v: Number => v
     }
     appendMetricType(buffer, name, "gauge")

--- a/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/StatsDReporter.scala
+++ b/metrics-dropwizard/src/main/scala/com/mesosphere/usi/metrics/dropwizard/reporters/StatsDReporter.scala
@@ -41,20 +41,22 @@ class StatsDReporter(settings: StatsdReporterSettings, registry: MetricRegistry)
   }
 
   private def report(socket: ActorRef): Unit = {
-    report(socket,
-     registry.getGauges,
-     registry.getCounters,
-     registry.getHistograms,
-     registry.getMeters,
-     registry.getTimers)
+    report(
+      socket,
+      registry.getGauges,
+      registry.getCounters,
+      registry.getHistograms,
+      registry.getMeters,
+      registry.getTimers)
   }
 
-  private def report(socket: ActorRef,
-   gauges: util.SortedMap[String, Gauge[_]],
-   counters: util.SortedMap[String, Counter],
-   histograms: util.SortedMap[String, Histogram],
-   meters: util.SortedMap[String, Meter],
-   timers: util.SortedMap[String, Timer]): Unit = {
+  private def report(
+      socket: ActorRef,
+      gauges: util.SortedMap[String, Gauge[_]],
+      counters: util.SortedMap[String, Counter],
+      histograms: util.SortedMap[String, Histogram],
+      meters: util.SortedMap[String, Meter],
+      timers: util.SortedMap[String, Timer]): Unit = {
 
     gauges.asScala.foreach {
       case (name, value) => reportGauge(socket, name, value)

--- a/metrics/.scalafmt.conf
+++ b/metrics/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none

--- a/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
+++ b/metrics/src/main/scala/com/mesosphere/usi/metrics/Metrics.scala
@@ -67,9 +67,10 @@ trait Timer extends TimerAdapter {
 trait Metrics {
   def counter(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Counter
   def gauge(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): Gauge
-  def closureGauge[N](name: String,
-                      currentValue: () => N,
-                      unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge
+  def closureGauge[N](
+      name: String,
+      currentValue: () => N,
+      unit: UnitOfMeasurement = UnitOfMeasurement.None): ClosureGauge
   def settableGauge(name: String, unit: UnitOfMeasurement = UnitOfMeasurement.None): SettableGauge
   def meter(name: String): Meter
   def timer(name: String): Timer

--- a/persistence/.scalafmt.conf
+++ b/persistence/.scalafmt.conf
@@ -1,4 +1,0 @@
-maxColumn = 120
-includeCurlyBraceInSelectChains = false
-includeNoParensInSelectChains = false
-align = none


### PR DESCRIPTION
The main feature in this diff is:
- now we require only one scalafmt config (!) not one copy-pasted into every module (and yes, we have a lot of these 🙈 )
- as a part of feedback I dropped `apply plugin: 'cz.alenkacz.gradle.scalafmt'` from last PR, which means that all projects did not have that task applied only the root one so lots of fixes in that PR were not applied, the way it is now is correct
- unfortunately `includeNoParensInSelectChains` is scalafmt 2.0 feature and there's only RC now, so we cannot use that. I am so sorry but for now we will have to live with 
```
Call
      .newBuilder()
```