### PR TITLE
Add missing keys for the `apt-get update`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: scala
 scala:
    - 2.12.2
 script:
-  - sudo ./gradlew provision
-  - ./gradlew ci --info
+  - sudo ./gradlew provision && ./gradlew ci --info
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -11,6 +11,8 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | \
     sudo tee /etc/apt/sources.list.d/mesosphere.list
 
+# Some keys are missing from time to time - add them manually
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
 apt-get -y update
 
 # Install Mesos

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -16,4 +16,4 @@ apt-get -y update -o Dir::Etc::sourcelist="sources.list.d/mesosphere.list" \
     -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 
 # Install Mesos
-apt-get -y install mesos="$MESOS_VERSION-2.0.3" zookeeperd
+apt-get -y install mesos="$MESOS_VERSION-2.0.3"

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -3,12 +3,17 @@ set -x -e -o pipefail
 
 MESOS_VERSION=$1
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF
 DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 CODENAME=$(lsb_release -cs)
 
+# Add Mesosphere repo to the list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | \
     sudo tee /etc/apt/sources.list.d/mesosphere.list
-apt-get -y update
 
+# Update only Mesosphere repository
+apt-get -y update -o Dir::Etc::sourcelist="sources.list.d/mesosphere.list" \
+    -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+
+# Install Mesos
 apt-get -y install mesos="$MESOS_VERSION-2.0.3" zookeeperd

--- a/ci/provision.sh
+++ b/ci/provision.sh
@@ -11,9 +11,7 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | \
     sudo tee /etc/apt/sources.list.d/mesosphere.list
 
-# Update only Mesosphere repository
-apt-get -y update -o Dir::Etc::sourcelist="sources.list.d/mesosphere.list" \
-    -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+apt-get -y update
 
 # Install Mesos
 apt-get -y install mesos="$MESOS_VERSION-2.0.3"


### PR DESCRIPTION
Summary:
from time to time a repository key is missing so we add it manually. Additionally, we now exit the build if provisioning failed.