### PR TITLE
Fix resourceutil test

### DIFF
--- a/core/src/main/scala/com/mesosphere/package.scala
+++ b/core/src/main/scala/com/mesosphere/package.scala
@@ -60,8 +60,8 @@ package mesosphere {
     *    // deleted immediately after. This happens every time the `logger` object is used to generate a log statement.
     * }}}
     */
-  case class LoggingArgs(args:(String, Any)*) {
-    def and(other:(String, Any)*): LoggingArgs = LoggingArgs(args ++ other:_*)
+  case class LoggingArgs(args: (String, Any)*) {
+    def and(other: (String, Any)*): LoggingArgs = LoggingArgs(args ++ other: _*)
   }
 
   /**

--- a/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
@@ -91,7 +91,12 @@ private[usi] object ProtoBuilders {
 
     reservations.foreach(b.addReservations)
 
-    if (allocationInfo != null) b.setAllocationInfo(allocationInfo)
+    if (allocationInfo != null) {
+      b.setAllocationInfo(allocationInfo)
+    } else {
+      // allocation info is required property
+      b.setAllocationInfo(Mesos.Resource.AllocationInfo.newBuilder())
+    }
     if (disk != null) b.setDisk(disk)
     if (providerId != null) b.setProviderId(providerId)
     if (ranges != null) b.setRanges(ranges)

--- a/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
@@ -30,7 +30,7 @@ private[usi] object ProtoBuilders {
       agentId: Mesos.AgentID,
       frameworkID: Mesos.FrameworkID,
       hostname: String,
-      allocationInfo: Mesos.Resource.AllocationInfo = null,
+      allocationInfo: Mesos.Resource.AllocationInfo,
       domain: Mesos.DomainInfo = null,
       executorIds: Iterable[Mesos.ExecutorID] = Nil,
       attributes: Iterable[Mesos.Attribute] = Nil,
@@ -43,17 +43,12 @@ private[usi] object ProtoBuilders {
       .setId(id)
       .setAgentId(agentId)
       .setHostname(hostname)
+      .setAllocationInfo(allocationInfo)
 
     attributes.foreach(b.addAttributes)
     executorIds.foreach(b.addExecutorIds)
     resources.foreach(b.addResources)
 
-    if (allocationInfo != null) {
-      b.setAllocationInfo(allocationInfo)
-    } else {
-      // allocation info is required property
-      b.setAllocationInfo(Mesos.Resource.AllocationInfo.newBuilder())
-    }
     if (domain != null) b.setDomain(domain)
     if (frameworkID != null) b.setFrameworkId(frameworkID)
     if (unavailability != null) b.setUnavailability(unavailability)
@@ -77,11 +72,18 @@ private[usi] object ProtoBuilders {
     b.build()
   }
 
+  def newResourceAllocationInfo(role: String): Mesos.Resource.AllocationInfo = {
+    Mesos.Resource.AllocationInfo
+      .newBuilder()
+      .setRole(role)
+      .build()
+  }
+
   def newResource(
       name: String,
       resourceType: Mesos.Value.Type,
+      allocationInfo: Mesos.Resource.AllocationInfo,
       reservations: Iterable[Mesos.Resource.ReservationInfo] = Nil,
-      allocationInfo: Mesos.Resource.AllocationInfo = null,
       disk: Mesos.Resource.DiskInfo = null,
       providerId: Mesos.ResourceProviderID = null,
       ranges: Mesos.Value.Ranges = null,
@@ -89,19 +91,15 @@ private[usi] object ProtoBuilders {
       scalar: Mesos.Value.Scalar = null,
       set: Mesos.Value.Set = null,
       shared: Mesos.Resource.SharedInfo = null): Mesos.Resource = {
-    val b = Mesos.Resource.newBuilder()
 
-    b.setType(resourceType)
-    b.setName(name)
+    val b = Mesos.Resource
+      .newBuilder()
+      .setType(resourceType)
+      .setName(name)
+      .setAllocationInfo(allocationInfo)
 
     reservations.foreach(b.addReservations)
 
-    if (allocationInfo != null) {
-      b.setAllocationInfo(allocationInfo)
-    } else {
-      // allocation info is required property
-      b.setAllocationInfo(Mesos.Resource.AllocationInfo.newBuilder())
-    }
     if (disk != null) b.setDisk(disk)
     if (providerId != null) b.setProviderId(providerId)
     if (ranges != null) b.setRanges(ranges)

--- a/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/protos/ProtoBuilders.scala
@@ -48,7 +48,12 @@ private[usi] object ProtoBuilders {
     executorIds.foreach(b.addExecutorIds)
     resources.foreach(b.addResources)
 
-    if (allocationInfo != null) b.setAllocationInfo(allocationInfo)
+    if (allocationInfo != null) {
+      b.setAllocationInfo(allocationInfo)
+    } else {
+      // allocation info is required property
+      b.setAllocationInfo(Mesos.Resource.AllocationInfo.newBuilder())
+    }
     if (domain != null) b.setDomain(domain)
     if (frameworkID != null) b.setFrameworkId(frameworkID)
     if (unavailability != null) b.setUnavailability(unavailability)

--- a/core/src/test/scala/com/mesosphere/usi/core/ResourceUtilTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/ResourceUtilTest.scala
@@ -40,7 +40,7 @@ class ResourceUtilTest extends UnitTest {
   }
 
   "ResourceUtil" should {
-    "have no leftover for empty resources" in {
+    "have no leftOvers for empty resources" in {
       val leftOvers = ResourceUtil.consumeResources(
         Seq(),
         Seq(ports(2 to 12))

--- a/core/src/test/scala/com/mesosphere/usi/core/ResourceUtilTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/ResourceUtilTest.scala
@@ -30,13 +30,16 @@ class ResourceUtilTest extends UnitTest {
       resourceType: ResourceType,
       amount: T,
       reservations: Iterable[Protos.Resource.ReservationInfo] = Nil,
-      disk: Option[DiskInfo] = None): Protos.Resource = {
+      disk: Option[DiskInfo] = None,
+      role: String = "mock-role"): Protos.Resource = {
     ProtoBuilders.newResource(
       resourceType.name,
       Protos.Value.Type.SCALAR,
+      ProtoBuilders.newResourceAllocationInfo(role),
       scalar = amount.asProtoScalar,
       reservations = reservations,
-      disk = disk.getOrElse(null))
+      disk = disk.getOrElse(null)
+    )
   }
 
   "ResourceUtil" should {
@@ -282,7 +285,11 @@ class ResourceUtilTest extends UnitTest {
   }
 
   private[this] def set(resourceType: ResourceType, labels: Set[String]): Protos.Resource = {
-    ProtoBuilders.newResource(resourceType.name, Protos.Value.Type.SET, set = labels.asProtoSet)
+    ProtoBuilders.newResource(
+      resourceType.name,
+      Protos.Value.Type.SET,
+      ProtoBuilders.newResourceAllocationInfo("some-role"),
+      set = labels.asProtoSet)
   }
 
   private[this] def portsTest(
@@ -303,7 +310,9 @@ class ResourceUtilTest extends UnitTest {
     ProtoBuilders.newResource(
       ResourceType.PORTS.name,
       Protos.Value.Type.RANGES,
-      ranges = ProtoBuilders.newValueRanges(ranges.map(_.asProtoRange)))
+      ProtoBuilders.newResourceAllocationInfo("some-role"),
+      ranges = ProtoBuilders.newValueRanges(ranges.map(_.asProtoRange))
+    )
   }
 
   private[this] def scalarTest(consumedResource: Double, baseResource: Double, expectedResult: Option[Double]): Unit = {

--- a/core/src/test/scala/com/mesosphere/usi/core/helpers/MesosMock.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/helpers/MesosMock.scala
@@ -22,10 +22,23 @@ object MesosMock {
           agentId = mockAgentId.asProto,
           frameworkID = mockFrameworkId,
           hostname = "some-host",
+          newResourceAllocationInfo("some-role"),
           resources = Seq(
-            newResource("cpus", Mesos.Value.Type.SCALAR, scalar = 4.asProtoScalar),
-            newResource("mem", Mesos.Value.Type.SCALAR, scalar = 4096.asProtoScalar),
-            newResource("disk", Mesos.Value.Type.SCALAR, scalar = 256000.asProtoScalar)
+            newResource(
+              "cpus",
+              Mesos.Value.Type.SCALAR,
+              newResourceAllocationInfo("some-role"),
+              scalar = 4.asProtoScalar),
+            newResource(
+              "mem",
+              Mesos.Value.Type.SCALAR,
+              newResourceAllocationInfo("some-role"),
+              scalar = 4096.asProtoScalar),
+            newResource(
+              "disk",
+              Mesos.Value.Type.SCALAR,
+              newResourceAllocationInfo("some-role"),
+              scalar = 256000.asProtoScalar)
           )
         )
 

--- a/core/src/test/scala/com/mesosphere/usi/core/matching/ScalarResourceRequirementTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/matching/ScalarResourceRequirementTest.scala
@@ -14,7 +14,12 @@ class ScalarResourceRequirementTest extends UnitTest with Inside {
       val matchers = ScalarResourceRequirement(ResourceType.CPUS, 2.0)
 
       val resources =
-        List(ProtoBuilders.newResource(ResourceType.CPUS.name, Mesos.Value.Type.SCALAR, scalar = 10.asProtoScalar))
+        List(
+          ProtoBuilders.newResource(
+            ResourceType.CPUS.name,
+            Mesos.Value.Type.SCALAR,
+            ProtoBuilders.newResourceAllocationInfo("some-role"),
+            scalar = 10.asProtoScalar))
       inside(matchers.matchAndConsume(resources)) {
         case Some(ResourceMatchResult(List(matchedResult), List(unmatched))) =>
           matchedResult.getScalar.getValue shouldBe 2.0


### PR DESCRIPTION
AllocationInfo is required by our `ResourceMatchKey` class. So we should set it in our builders or drop that requirment. This PR chose the first path...

@timcharper are we sure that there cannot be resource coming from mesos without the allocation info?

This test is still not run as part of our build though. That will happen with #47