### PR TITLE
In CI, fail on incorrect formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
    - 2.12.7
 script:
-  - sudo ./gradlew provision && ./gradlew ci --info
+  - sudo ./gradlew provision && ./gradlew checkScalaFmtAll ci --info
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
    - 2.12.7
 script:
-  - sudo ./gradlew checkScalaFmtAll && ./gradlew provision && ./gradlew ci --info
+  - sudo ./gradlew provision && ./gradlew checkScalaFmtAll ci --info
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 jdk:
   - openjdk11
 language: scala
+install:
+  - true
 scala:
    - 2.12.7
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
    - 2.12.7
 script:
-  - sudo ./gradlew provision && ./gradlew checkScalaFmtAll ci --info
+  - sudo ./gradlew checkScalaFmtAll && ./gradlew provision && ./gradlew ci --info
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 jdk:
   - openjdk11
 language: scala
+# this is necessary because otherwise travis runs gradlew assemble before out tasks
+# and if that is run, checkScalaFmtAll won't work
 install:
   - true
 scala:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
    - 2.12.7
 script:
-  - sudo ./gradlew provision && ./gradlew checkScalaFmtAll ci --info
+  - ./gradlew checkScalaFmtAll && sudo ./gradlew provision && ./gradlew ci --info
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
         scalaCompileOptions.additionalParameters = ["-Xlint", "-Xfatal-warnings"]
     }
 
-    // compileScala.dependsOn scalafmtAll
+    compileScala.dependsOn scalafmtAll
 
     dependencies {
         // Use Scala 2.12 in our library project

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
         scalaCompileOptions.additionalParameters = ["-Xlint", "-Xfatal-warnings"]
     }
 
-    compileScala.dependsOn scalafmtAll
+    // compileScala.dependsOn scalafmtAll
 
     dependencies {
         // Use Scala 2.12 in our library project

--- a/core/src/test/scala/com/mesosphere/usi/core/helpers/MesosMock.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/helpers/MesosMock.scala
@@ -63,11 +63,7 @@ object MesosMock {
           Mesos.Value.Type.SCALAR,
           newResourceAllocationInfo("some-role"),
           scalar = cpus.asProtoScalar),
-        newResource(
-          "mem",
-          Mesos.Value.Type.SCALAR,
-          newResourceAllocationInfo("some-role"),
-          scalar = mem.asProtoScalar),
+        newResource("mem", Mesos.Value.Type.SCALAR, newResourceAllocationInfo("some-role"), scalar = mem.asProtoScalar),
         newResource(
           "disk",
           Mesos.Value.Type.SCALAR,

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -32,14 +32,14 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
     input.offer(
       PodSpecUpdated(
         podId,
-        Some(PodSpec(
-          podId,
-          Goal.Running,
-          RunSpec(
-            resourceRequirements =
-              List(ScalarResource.cpus(1), ScalarResource.memory(256)),
-            shellCommand = "sleep 3600")
-        ))
+        Some(
+          PodSpec(
+            podId,
+            Goal.Running,
+            RunSpec(
+              resourceRequirements = List(ScalarResource.cpus(1), ScalarResource.memory(256)),
+              shellCommand = "sleep 3600")
+          ))
       ))
 
     inside(output.pull().futureValue) {


### PR DESCRIPTION
As we agreed in Slack, we should fail the build on incorrect formatting. At the same time we want compile to automatically format the code -> we need to run this before the ci pipeline starts.