### PR TITLE
Make it possible to disable randomized port shuffling

### DIFF
--- a/core/src/main/scala/com/mesosphere/usi/core/matching/RangeResource.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/RangeResource.scala
@@ -21,7 +21,10 @@ import scala.util.Random
   * @param resourceType name of resource (e.g. ports)
   * @param random when requesting dynamic values, you can provide Random implementation if you want dynamic values to be randomized
   */
-case class RangeResource(requestedValues: Seq[RequestedValue], resourceType: ResourceType, random: Option[Random] = Some(Random))
+case class RangeResource(
+    requestedValues: Seq[RequestedValue],
+    resourceType: ResourceType,
+    random: Option[Random] = Some(Random))
     extends ResourceRequirement {
   override def description: String = s"$resourceType:[${requestedValues.mkString(",")}]"
 
@@ -74,12 +77,14 @@ case class RangeResource(requestedValues: Seq[RequestedValue], resourceType: Res
     // non-dynamic values
     val staticRequestedValues = requestedValues.collect { case ExactValue(v) => v }.toSet
     val availableForDynamicAssignment: Iterator[Int] = random match {
-      case Some(r) => lazyRandomValuesFromRanges(offeredRanges, r)
-        .filter(v => !staticRequestedValues(v))
-      case None => offeredRanges
-        .map(_.iterator)
-        .foldLeft(Iterator[Int]())(_ ++ _)
-        .filter(v => !staticRequestedValues(v))
+      case Some(r) =>
+        lazyRandomValuesFromRanges(offeredRanges, r)
+          .filter(v => !staticRequestedValues(v))
+      case None =>
+        offeredRanges
+          .map(_.iterator)
+          .foldLeft(Iterator[Int]())(_ ++ _)
+          .filter(v => !staticRequestedValues(v))
     }
 
     val matchResult = requestedValues.map {

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/RangeResource.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/RangeResource.scala
@@ -21,7 +21,7 @@ import scala.util.Random
   * @param resourceType name of resource (e.g. ports)
   * @param random when requesting dynamic values, you can provide Random implementation if you want dynamic values to be randomized
   */
-case class RangeResource(requestedValues: Seq[RequestedValue], resourceType: ResourceType, random: Random = Random)
+case class RangeResource(requestedValues: Seq[RequestedValue], resourceType: ResourceType, random: Option[Random] = Some(Random))
     extends ResourceRequirement {
   override def description: String = s"$resourceType:[${requestedValues.mkString(",")}]"
 
@@ -73,8 +73,14 @@ case class RangeResource(requestedValues: Seq[RequestedValue], resourceType: Res
 
     // non-dynamic values
     val staticRequestedValues = requestedValues.collect { case ExactValue(v) => v }.toSet
-    val availableForDynamicAssignment: Iterator[Int] =
-      lazyRandomValuesFromRanges(offeredRanges, random).filter(v => !staticRequestedValues(v))
+    val availableForDynamicAssignment: Iterator[Int] = random match {
+      case Some(r) => lazyRandomValuesFromRanges(offeredRanges, r)
+        .filter(v => !staticRequestedValues(v))
+      case None => offeredRanges
+        .map(_.iterator)
+        .foldLeft(Iterator[Int]())(_ ++ _)
+        .filter(v => !staticRequestedValues(v))
+    }
 
     val matchResult = requestedValues.map {
       case RandomValue if !availableForDynamicAssignment.hasNext =>
@@ -195,7 +201,7 @@ case object RandomValue extends RequestedValue
 object RangeResource {
   val RandomPort: Int = 0
 
-  def ports(requestedPorts: Seq[Int], random: Random = Random): RangeResource = {
+  def ports(requestedPorts: Seq[Int], random: Option[Random] = Some(Random)): RangeResource = {
     new RangeResource(
       requestedPorts.map(p => if (p == RandomPort) RandomValue else ExactValue(p)),
       ResourceType.PORTS,

--- a/core/src/test/scala/com/mesosphere/usi/core/matching/RangeResourceTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/matching/RangeResourceTest.scala
@@ -105,7 +105,7 @@ class RangeResourceTest extends UnitTestLike {
       val alwaysSameMatch = (1 to 10).find { _ =>
         val matchResource = resource.matchAndConsume(Seq(resourceWithPortRange(Range(2000, 2400))))
         matchResource.get.matchedResources.head.getRanges.getRange(0).getBegin != 2000 ||
-          matchResource.get.matchedResources.head.getRanges.getRange(0).getEnd != 2000
+        matchResource.get.matchedResources.head.getRanges.getRange(0).getEnd != 2000
       }
 
       alwaysSameMatch.isEmpty should be(true) withClue "when no random shuffling is requested, selected port should always be the same"

--- a/core/src/test/scala/com/mesosphere/usi/core/matching/RangeResourceTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/matching/RangeResourceTest.scala
@@ -79,16 +79,16 @@ class RangeResourceTest extends UnitTestLike {
     }
 
     "select the ports in random ranges" in {
-      val resource1 = RangeResource.ports(Seq(0), new util.Random(0))
+      val resource1 = RangeResource.ports(Seq(0), Some(new util.Random(0)))
       val match1 = resource1.matchAndConsume(Seq(resourceWithPortRange(Range(2000, 2400))))
-      val resource2SameSeed = RangeResource.ports(Seq(0), new util.Random(0))
+      val resource2SameSeed = RangeResource.ports(Seq(0), Some(new util.Random(0)))
       val match2 = resource2SameSeed.matchAndConsume(Seq(resourceWithPortRange(Range(2000, 2400))))
 
       match1.get.matchedResources.head.getRanges.getRange(0) should be(
         match2.get.matchedResources.head.getRanges.getRange(0))
 
       val differentMatch = (1 to 100).find { seed =>
-        val resource2DifferentSeed = RangeResource.ports(Seq(0), new util.Random(seed))
+        val resource2DifferentSeed = RangeResource.ports(Seq(0), Some(new util.Random(seed)))
         val match3 = resource2DifferentSeed.matchAndConsume(Seq(resourceWithPortRange(Range(2000, 2400))))
         match1.get.matchedResources.head.getRanges.getRange(0).getBegin == match3.get.matchedResources.head.getRanges
           .getRange(0)
@@ -98,6 +98,17 @@ class RangeResourceTest extends UnitTestLike {
       }
 
       differentMatch.isDefined should be(true) withClue "Expecting ports to be selected at random"
+    }
+
+    "not select ports random when random not provided" in {
+      val resource = RangeResource.ports(Seq(0), None)
+      val alwaysSameMatch = (1 to 10).find { _ =>
+        val matchResource = resource.matchAndConsume(Seq(resourceWithPortRange(Range(2000, 2400))))
+        matchResource.get.matchedResources.head.getRanges.getRange(0).getBegin != 2000 ||
+          matchResource.get.matchedResources.head.getRanges.getRange(0).getEnd != 2000
+      }
+
+      alwaysSameMatch.isEmpty should be(true) withClue "when no random shuffling is requested, selected port should always be the same"
     }
   }
 


### PR DESCRIPTION
I think it's pretty valid to not require the random shuffling. e.g. SDK does not do it right now.

JIRA: DCOS-47481