### PR TITLE
Introduce basic `PodSpec` validation

### DIFF
--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
@@ -1,5 +1,9 @@
 package com.mesosphere.usi.core.models
 
+import com.mesosphere.usi.core.models.resources.{ExactValue, RangeRequirement}
+
+import scala.util.{Failure, Success, Try}
+
 /**
   * Framework implementation owned specification of some Pod that should be launched.
   *
@@ -12,4 +16,42 @@ package com.mesosphere.usi.core.models
   * @param goal target goal of this pod. See [[Goal]] for more details
   * @param runSpec WIP the thing to run, and resource requirements, etc.
   */
-case class PodSpec(id: PodId, goal: Goal, runSpec: RunSpec)
+trait PodSpec {
+  def id: PodId
+  def goal: Goal
+  def runSpec: RunSpec
+}
+
+object PodSpec {
+
+  type ErrorMessage = String
+
+  /**
+    * Verifies that every value in range is requested only once. Requesting same value multiple times would yield pod that will never be scheduled.
+    * E.g. requesting two ports 80 on one machine is just not possible to satisfy
+    * @param runSpec runSpec we are validating
+    * @return true if provided range requirements are valid
+    */
+  private def validateRunSpec(runSpec: RunSpec): Option[ErrorMessage] = {
+    val staticPorts = runSpec.resourceRequirements.collect {
+      case RangeRequirement(requestedValues, _, _) => requestedValues
+    }.flatten.collect { case ExactValue(value) => value }
+
+    if (staticPorts.distinct.length != staticPorts.length) {
+      Some(s"Every value inside RangeResource can be requested only once. Requirement: ${staticPorts.mkString(",")}")
+    }
+
+    None
+  }
+
+  def apply(id: PodId, goal: Goal, runSpec: RunSpec): Try[PodSpec] = {
+    val validationError = validateRunSpec(runSpec)
+
+    validationError match {
+      case Some(error) => Failure(new IllegalArgumentException(error))
+      case None => Success(PodSpecImpl(id, goal, runSpec))
+    }
+  }
+
+  private case class PodSpecImpl(id: PodId, goal: Goal, runSpec: RunSpec) extends PodSpec
+}

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -57,7 +57,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
             RunSpec(
               resourceRequirements = List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256)),
               shellCommand = "sleep 3600")
-          ))
+          ).get)
       ))
 
     inside(output.pull().futureValue) {

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -57,7 +57,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
             RunSpec(
               resourceRequirements = List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256)),
               shellCommand = "sleep 3600")
-          ).get)
+          ).right.get)
       ))
 
     inside(output.pull().futureValue) {

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -50,7 +50,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
             RunSpec(
               resourceRequirements = List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256)),
               shellCommand = "sleep 3600")
-          ))
+          ).get)
       ))
 
     inside(output.pull().futureValue) {
@@ -85,7 +85,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
             resourceRequirements =
               List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256), RangeRequirement.ports(Seq(0))),
             shellCommand = "sleep 3600")
-        ))
+        ).get)
       ))
 
     eventually {

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -50,7 +50,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
             RunSpec(
               resourceRequirements = List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256)),
               shellCommand = "sleep 3600")
-          ).get)
+          ).right.get)
       ))
 
     inside(output.pull().futureValue) {
@@ -85,7 +85,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
             resourceRequirements =
               List(ScalarRequirement.cpus(1), ScalarRequirement.memory(256), RangeRequirement.ports(Seq(0))),
             shellCommand = "sleep 3600")
-        ).get)
+        ).right.get)
       ))
 
     eventually {

--- a/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
@@ -21,7 +21,7 @@ class MesosEventsLogicTest extends UnitTest {
       RunSpec(
         Seq(ScalarRequirement(ResourceType.CPUS, 1), ScalarRequirement(ResourceType.MEM, 256)),
         shellCommand = "sleep 3600")
-    ).get
+    ).right.get
 
   "MesosEventsLogic" should {
     "decline an offer when there is no PodSpec to launch" in {
@@ -45,7 +45,7 @@ class MesosEventsLogicTest extends UnitTest {
             PodId("mock-podId"),
             Goal.Running,
             RunSpec(Seq(ScalarRequirement(ResourceType.CPUS, Integer.MAX_VALUE)), shellCommand = "sleep 3600")
-          ).get
+          ).right.get
         )
       )
       schedulerEventsBuilder.result.mesosCalls.size shouldBe 1

--- a/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
@@ -16,7 +16,7 @@ class MesosEventsLogicTest extends UnitTest {
 
   def podWith1Cpu256Mem(id: String = "mock-podId"): PodSpec =
     PodSpec(
-      PodId("mock-podId"),
+      PodId(id),
       Goal.Running,
       RunSpec(
         Seq(ScalarRequirement(ResourceType.CPUS, 1), ScalarRequirement(ResourceType.MEM, 256)),

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -108,8 +108,8 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
     goal = Goal.Running,
     runSpec = runSpec
   ) match {
-    case Success(value) => value
-    case Failure(exception) => throw exception
+    case Right(value) => value
+    case Left(errors) => throw new RuntimeException(errors.mkString(","))
   }
 
   val specsSnapshot = SpecsSnapshot(

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -29,6 +29,7 @@ import org.apache.mesos.v1.Protos.{FrameworkInfo, TaskState, TaskStatus}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.sys.SystemProperties
+import scala.util.{Failure, Success}
 
 /**
   * Run the hello-world example framework that:
@@ -106,7 +107,10 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
     id = podId,
     goal = Goal.Running,
     runSpec = runSpec
-  )
+  ) match {
+    case Success(value) => value
+    case Failure(exception) => throw exception
+  }
 
   val specsSnapshot = SpecsSnapshot(
     podSpecs = Seq(podSpec),


### PR DESCRIPTION
My proposal is:
- never let anyone create invalid (not-validated) object, thus we have PodSpec trait and private impl (if we agree on this direction I will do the same for RunSpec - thanks Aleksey for that feedback)
- I went with `Either[Seq[ValidationError], PodSpec]` - I think it's pretty much equal to `PodSpec Or Every[ErrorMessage]`
- All validation methods now return `Seq[ValidationError]` thus supporting one or many errors (I don't see reason why we would need to distinguish between one or more errors on this level) ... I find that nicer than `Unit Or Every[ErrorMessage]`
- I've added 5 lines long `validationErrorOrResult` method that does the accumulation