### PR TITLE
Make `core-hello-world` example framework ready for deployment

### DIFF
--- a/examples/core-hello-world/build.gradle
+++ b/examples/core-hello-world/build.gradle
@@ -1,3 +1,11 @@
+plugins {
+    id 'application'
+}
+
+application {
+    mainClassName = 'com.mesosphere.usi.examples.CoreHelloWorldFramework'
+}
+
 dependencies {
     implementation project(':core')
     testCompile project(':test-utils')

--- a/examples/core-hello-world/src/main/resources/application.conf
+++ b/examples/core-hello-world/src/main/resources/application.conf
@@ -2,6 +2,7 @@
 mesos-client {
 
   master-url: "127.0.0.1:5050"
+  master-url: ${?MESOS_MASTER_URL}
 
   redirect-retries: 3
 

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.stream.ActorMaterializer
 import com.mesosphere.mesos.client.MesosClient
 import com.mesosphere.mesos.conf.MesosClientSettings
 import com.mesosphere.usi.core.Scheduler
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success}
   */
 class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
   implicit val system = ActorSystem()
-  implicit val mat = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
+  implicit val mat = ActorMaterializer()
   implicit val ec = system.dispatcher
 
   val settings = MesosClientSettings(conf.getString("master-url"))

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -4,13 +4,24 @@ import java.util.UUID
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import com.mesosphere.mesos.client.MesosClient
 import com.mesosphere.mesos.conf.MesosClientSettings
 import com.mesosphere.usi.core.Scheduler
 import com.mesosphere.usi.core.models.resources.ScalarRequirement
-import com.mesosphere.usi.core.models.{Goal, PodId, PodSpec, PodStatus, PodStatusUpdated, RunSpec, SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot}
+import com.mesosphere.usi.core.models.{
+  Goal,
+  PodId,
+  PodSpec,
+  PodStatus,
+  PodStatusUpdated,
+  RunSpec,
+  SpecUpdated,
+  SpecsSnapshot,
+  StateEvent,
+  StateSnapshot
+}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.Protos.{FrameworkInfo, TaskState, TaskStatus}
@@ -90,7 +101,7 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
   val podId = PodId(s"hello-world.${UUID.randomUUID()}")
   val runSpec = RunSpec(
     resourceRequirements = List(ScalarRequirement.cpus(0.1), ScalarRequirement.memory(32)),
-    shellCommand = """echo "Hello, world" && sleep 3600"""
+    shellCommand = """echo "Hello, world" && sleep 123456789"""
   )
   val podSpec = PodSpec(
     id = podId,
@@ -141,6 +152,14 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
     }
     .toMat(Sink.ignore)(Keep.right)
     .run()
+    .onComplete {
+      case Success(res) =>
+        logger.info(s"Stream completed: $res");
+        system.terminate()
+      case Failure(e) =>
+        logger.error(s"Error in stream: $e");
+        system.terminate()
+    }
 }
 
 object CoreHelloWorldFramework {

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -2,13 +2,11 @@ package com.mesosphere.usi.examples
 
 import java.util
 
-import com.mesosphere.usi.core.models.{PodStatus, PodStatusUpdated}
 import com.mesosphere.utils.AkkaUnitTest
 import com.mesosphere.utils.mesos.MesosClusterTest
 import com.mesosphere.utils.mesos.MesosFacade.ITFramework
 import com.typesafe.config.ConfigFactory
 import org.apache.mesos.v1.Protos.FrameworkID
-import org.apache.mesos.v1.Protos.TaskState.TASK_RUNNING
 import org.scalatest.Inside
 
 class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest with Inside {
@@ -30,17 +28,6 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
       val task = framework.tasks.head
       task.name should startWith("hello-world")
       task.state.get shouldBe "TASK_RUNNING"
-    }
-
-    And("scheduler produces a PodStatusUpdated event with a running task")
-    eventually {
-      inside(f.framework.output.pull().futureValue) {
-        case Some(PodStatusUpdated(id, Some(PodStatus(_, taskStatuses)))) =>
-          id shouldBe f.framework.podId
-          taskStatuses.head match {
-            case (_, status) => status.getState shouldBe TASK_RUNNING
-          }
-      }
     }
   }
 


### PR DESCRIPTION
Summary:
- applied application plugin so we can build a tarball with all dependencies using `gradle :core-hello-world:distTar`
- replaced materialization to the `Source.queue` with `Source.ignore`. This is makes testing harder but queue is not suitable for production (back-pressure will kick in, effectively halting the stream)
- make mesos master url overridable from the environment variable

JIRA: DCOS-47868