### PR TITLE
HelloWorld framework: Don't swallow exceptions in Main

### DIFF
--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -60,113 +60,124 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
     .setFailoverTimeout(0d)
     .build()
 
-  val client: MesosClient = Await.result(MesosClient(settings, frameworkInfo).runWith(Sink.head), 10.seconds)
+  def run(): Unit = {
+    val client: MesosClient = Await.result(MesosClient(settings, frameworkInfo).runWith(Sink.head), 10.seconds)
 
-  /**
-    * The signature of the [[schedulerFlow]] might look scary at the first glance (and sometimes even at second) but it is
-    * at the core (!) of any framework. Basically it is a Flow that [[SpecUpdated]] events as input and produces
-    * [[StateEvent]] as an output.
-    *
-    * +--------------------+         +-----------------------+        +-----------------------+
-    * |                    |         |                       |        |                       |
-    * |     SpecUpdated    |         |                       |        |      StateEvent       |
-    * |                    +--------->  Core SchedulerFlow   +-------->                       |
-    * |   new and updated  |         |                       |        | replicated Pod, Agent |
-    * |       PodSpecs     |         |                       |        | and Reservations state|
-    * +--------------------+         +-----------------------+        +-----------------------+
-    *
-    *
-    * In a nutshell: frameworks sends [[PodSpec]] updates down the flow and receives [[StateEvent]]s when things
-    * change. So why is the input parameter of that Flow not simply a [[SpecUpdated]] but a tuple of
-    * [[SpecsSnapshot]] and Source[[SpecUpdated]]? This is because the first message sent to the scheduler
-    * by the framework should be a snapshot of all PodSpecs known to the framework - a [[SpecsSnapshot]]. Internally
-    * this will trigger [task reconciliation](http://mesos.apache.org/documentation/latest/reconciliation/) by the
-    * scheduler.
-    *
-    * The same logic applies for the output parameter of the scheduler Flow - it's a tuple of [[StateSnapshot]] and a
-    * Source of [[StateEvent]], which means that the first state event received by the framework will be a
-    * snapshot of all reconciled tasks states, followed by a individual updates.
-    *
-    * For more about the scheduler flow see [[Scheduler]] class documentation.
-    *
-    */
-  val schedulerFlow
+    /**
+      * The signature of the [[schedulerFlow]] might look scary at the first glance (and sometimes even at second) but it is
+      * at the core (!) of any framework. Basically it is a Flow that [[SpecUpdated]] events as input and produces
+      * [[StateEvent]] as an output.
+      *
+      * +--------------------+         +-----------------------+        +-----------------------+
+      * |                    |         |                       |        |                       |
+      * |     SpecUpdated    |         |                       |        |      StateEvent       |
+      * |                    +--------->  Core SchedulerFlow   +-------->                       |
+      * |   new and updated  |         |                       |        | replicated Pod, Agent |
+      * |       PodSpecs     |         |                       |        | and Reservations state|
+      * +--------------------+         +-----------------------+        +-----------------------+
+      *
+      *
+      * In a nutshell: frameworks sends [[PodSpec]] updates down the flow and receives [[StateEvent]]s when things
+      * change. So why is the input parameter of that Flow not simply a [[SpecUpdated]] but a tuple of
+      * [[SpecsSnapshot]] and Source[[SpecUpdated]]? This is because the first message sent to the scheduler
+      * by the framework should be a snapshot of all PodSpecs known to the framework - a [[SpecsSnapshot]]. Internally
+      * this will trigger [task reconciliation](http://mesos.apache.org/documentation/latest/reconciliation/) by the
+      * scheduler.
+      *
+      * The same logic applies for the output parameter of the scheduler Flow - it's a tuple of [[StateSnapshot]] and a
+      * Source of [[StateEvent]], which means that the first state event received by the framework will be a
+      * snapshot of all reconciled tasks states, followed by a individual updates.
+      *
+      * For more about the scheduler flow see [[Scheduler]] class documentation.
+      *
+      */
+    val schedulerFlow
     : Flow[(SpecsSnapshot, Source[SpecUpdated, Any]), (StateSnapshot, Source[StateEvent, Any]), NotUsed] =
-    Scheduler.fromClient(client)
+      Scheduler.fromClient(client)
 
-  // Lets construct the initial specs snapshot which will contain our hello-world PodSpec. For that we generate
-  // - a unique PodId
-  // - a RunSpec with minimal resource requirements and hello-world shell command
-  // - a snapshot containing our PodSpec
-  val podId = PodId(s"hello-world.${UUID.randomUUID()}")
-  val runSpec = RunSpec(
-    resourceRequirements = List(ScalarRequirement.cpus(0.1), ScalarRequirement.memory(32)),
-    shellCommand = """echo "Hello, world" && sleep 123456789"""
-  )
-  val podSpec = PodSpec(
-    id = podId,
-    goal = Goal.Running,
-    runSpec = runSpec
-  )
+    // Lets construct the initial specs snapshot which will contain our hello-world PodSpec. For that we generate
+    // - a unique PodId
+    // - a RunSpec with minimal resource requirements and hello-world shell command
+    // - a snapshot containing our PodSpec
+    val podId = PodId(s"hello-world.${UUID.randomUUID()}")
+    val runSpec = RunSpec(
+      resourceRequirements = List(ScalarRequirement.cpus(0.1), ScalarRequirement.memory(32)),
+      shellCommand = """echo "Hello, world" && sleep 123456789"""
+    )
+    val podSpec = PodSpec(
+      id = podId,
+      goal = Goal.Running,
+      runSpec = runSpec
+    )
 
-  val specsSnapshot = SpecsSnapshot(
-    podSpecs = Seq(podSpec),
-    reservationSpecs = Seq.empty
-  )
+    val specsSnapshot = SpecsSnapshot(
+      podSpecs = Seq(podSpec),
+      reservationSpecs = Seq.empty
+    )
 
-  Source
-  // A trick to make our stream run, even after the initial element (snapshot) is consumed. We use Source.maybe
-  // which emits a materialized promise which when completed with a Some, that value will be produced downstream,
-  // followed by completion. To avoid stream completion we never complete the promise but prepend the stream with
-  // our snapshot together with an empty source for subsequent SpecUpdates (which we're not going to send)
-  //
-  // Note: this is hardly realistic since an orchestrator will need to react to StateEvents by sending SpecUpdates
-  // to the scheduler. We're making our lives easier by ignoring this part for now - all we care about is to start
-  // a "hello-world" task once.
-  .maybe
-    .prepend(Source.single(specsSnapshot))
-    .map(snapshot => (snapshot, Source.empty))
-    // Here our initial snapshot is going to the scheduler flow
-    .via(schedulerFlow)
-    // We flatten the output of the scheduler flow which is a tuple of an initial snapshot and a source of all
-    // later updates, into one stream where the first element is the snapshot and all later elements are single
-    // state events. This makes the event handling a simple match-case
-    .flatMapConcat {
+    Source
+      // A trick to make our stream run, even after the initial element (snapshot) is consumed. We use Source.maybe
+      // which emits a materialized promise which when completed with a Some, that value will be produced downstream,
+      // followed by completion. To avoid stream completion we never complete the promise but prepend the stream with
+      // our snapshot together with an empty source for subsequent SpecUpdates (which we're not going to send)
+      //
+      // Note: this is hardly realistic since an orchestrator will need to react to StateEvents by sending SpecUpdates
+      // to the scheduler. We're making our lives easier by ignoring this part for now - all we care about is to start
+      // a "hello-world" task once.
+      .maybe
+      .prepend(Source.single(specsSnapshot))
+      .map(snapshot => (snapshot, Source.empty))
+      // Here our initial snapshot is going to the scheduler flow
+      .via(schedulerFlow)
+      // We flatten the output of the scheduler flow which is a tuple of an initial snapshot and a source of all
+      // later updates, into one stream where the first element is the snapshot and all later elements are single
+      // state events. This makes the event handling a simple match-case
+      .flatMapConcat {
       case (snapshot, updates) =>
         updates.prepend(Source.single(snapshot))
     }
-    .map {
-      // Main state event handler. We log happy events and exit if something goes wrong
-      case PodStatusUpdated(id, Some(PodStatus(_, taskStatuses))) =>
-        import TaskState._
-        def activeTask(status: TaskStatus) = Seq(TASK_STAGING, TASK_STARTING, TASK_RUNNING).contains(status.getState)
+      .map {
+        // Main state event handler. We log happy events and exit if something goes wrong
+        case PodStatusUpdated(id, Some(PodStatus(_, taskStatuses))) =>
+          import TaskState._
+          def activeTask(status: TaskStatus) = Seq(TASK_STAGING, TASK_STARTING, TASK_RUNNING).contains(status.getState)
 
-        // We're only interested in the happy task statuses for our pod
-        val failedTasks = taskStatuses.filterNot { case (id, status) => activeTask(status) }
-        assert(failedTasks.isEmpty, s"Found failed tasks: $failedTasks, can't handle them now so will terminate")
+          // We're only interested in the happy task statuses for our pod
+          val failedTasks = taskStatuses.filterNot { case (id, status) => activeTask(status) }
+          assert(failedTasks.isEmpty, s"Found failed tasks: $failedTasks, can't handle them now so will terminate")
 
-        logger.info(s"Task status updates for podId: $id: ${taskStatuses}")
+          logger.info(s"Task status updates for podId: $id: ${taskStatuses}")
 
-      case e =>
-        logger.warn(s"Unhandled event: $e") // we ignore everything else for now
-    }
-    .toMat(Sink.ignore)(Keep.right)
-    .run()
-    .onComplete {
-      case Success(res) =>
-        logger.info(s"Stream completed: $res");
-        system.terminate()
-      case Failure(e) =>
-        logger.error(s"Error in stream: $e");
-        system.terminate()
-    }
+        case e =>
+          logger.warn(s"Unhandled event: $e") // we ignore everything else for now
+      }
+      .toMat(Sink.ignore)(Keep.right)
+      .run()
+      .onComplete {
+        case Success(res) =>
+          logger.info(s"Stream completed: $res");
+          system.terminate()
+        case Failure(e) =>
+          logger.error(s"Error in stream: $e");
+          system.terminate()
+      }
+  }
 }
 
 object CoreHelloWorldFramework {
 
   def main(args: Array[String]): Unit = {
     val conf = ConfigFactory.load().getConfig("mesos-client")
-    CoreHelloWorldFramework(conf)
+    val framework = CoreHelloWorldFramework(conf)
+    try {
+      framework.run()
+    } catch {
+      case ex: Throwable =>
+        System.err.println(s"Exception while starting framework! ${ex}")
+        ex.printStackTrace(System.err)
+        framework.system.terminate()
+        System.exit(1)
+    }
   }
 
   def apply(conf: Config): CoreHelloWorldFramework = new CoreHelloWorldFramework(conf)

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -92,7 +92,7 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
       *
       */
     val schedulerFlow
-    : Flow[(SpecsSnapshot, Source[SpecUpdated, Any]), (StateSnapshot, Source[StateEvent, Any]), NotUsed] =
+      : Flow[(SpecsSnapshot, Source[SpecUpdated, Any]), (StateSnapshot, Source[StateEvent, Any]), NotUsed] =
       Scheduler.fromClient(client)
 
     // Lets construct the initial specs snapshot which will contain our hello-world PodSpec. For that we generate
@@ -116,15 +116,15 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
     )
 
     Source
-      // A trick to make our stream run, even after the initial element (snapshot) is consumed. We use Source.maybe
-      // which emits a materialized promise which when completed with a Some, that value will be produced downstream,
-      // followed by completion. To avoid stream completion we never complete the promise but prepend the stream with
-      // our snapshot together with an empty source for subsequent SpecUpdates (which we're not going to send)
-      //
-      // Note: this is hardly realistic since an orchestrator will need to react to StateEvents by sending SpecUpdates
-      // to the scheduler. We're making our lives easier by ignoring this part for now - all we care about is to start
-      // a "hello-world" task once.
-      .maybe
+    // A trick to make our stream run, even after the initial element (snapshot) is consumed. We use Source.maybe
+    // which emits a materialized promise which when completed with a Some, that value will be produced downstream,
+    // followed by completion. To avoid stream completion we never complete the promise but prepend the stream with
+    // our snapshot together with an empty source for subsequent SpecUpdates (which we're not going to send)
+    //
+    // Note: this is hardly realistic since an orchestrator will need to react to StateEvents by sending SpecUpdates
+    // to the scheduler. We're making our lives easier by ignoring this part for now - all we care about is to start
+    // a "hello-world" task once.
+    .maybe
       .prepend(Source.single(specsSnapshot))
       .map(snapshot => (snapshot, Source.empty))
       // Here our initial snapshot is going to the scheduler flow
@@ -133,9 +133,9 @@ class CoreHelloWorldFramework(conf: Config) extends StrictLogging {
       // later updates, into one stream where the first element is the snapshot and all later elements are single
       // state events. This makes the event handling a simple match-case
       .flatMapConcat {
-      case (snapshot, updates) =>
-        updates.prepend(Source.single(snapshot))
-    }
+        case (snapshot, updates) =>
+          updates.prepend(Source.single(snapshot))
+      }
       .map {
         // Main state event handler. We log happy events and exit if something goes wrong
         case PodStatusUpdated(id, Some(PodStatus(_, taskStatuses))) =>

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -16,7 +16,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val frameworks: Seq[ITFramework] = mesosFacade.frameworks().value.frameworks
 
     val exampleFramework: ITFramework = frameworks.head
-    exampleFramework.id shouldBe f.framework.client.frameworkId.getValue
+    exampleFramework.id shouldBe f.framework.frameworkId.getValue
 
     And("example framework should be active and connected")
     exampleFramework.active shouldBe true
@@ -35,7 +35,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val f = new Fixture(frameworkId)
     try fn(f)
     finally {
-      f.framework.client.killSwitch.shutdown()
+      f.framework.killSwitch.shutdown()
     }
   }
 
@@ -46,6 +46,6 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
       .parseMap(util.Map.of("mesos-client.master-url", s"${mesosUrl.getHost}:${mesosUrl.getPort}"))
       .withFallback(ConfigFactory.load())
 
-    val framework = CoreHelloWorldFramework(conf.getConfig("mesos-client"))
+    val framework = CoreHelloWorldFramework.run(conf.getConfig("mesos-client"))
   }
 }


### PR DESCRIPTION
Summary:
The HelloWorld framework was not catching exceptions when attempting to get a MesosClient connection. This led to the appears that USI was swallowing exceptions, when in fact the exceptions were being returned, but they were being swallowed. Since the main thread is suspended until all actor systems are terminated, it gave the appearance that the USI stream was stalled without any progress.