### PR TITLE
Eager cancel the graph fanout

### DIFF
--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -109,7 +109,7 @@ object Scheduler {
         {
           import GraphDSL.Implicits._
 
-          val broadcast = builder.add(Broadcast[SchedulerEvents](2))
+          val broadcast = builder.add(Broadcast[SchedulerEvents](2, eagerCancel = true))
           val specInputFlattening = builder.add(specInputFlatteningFlow)
           val stateOutputBreakout = builder.add(stateOutputBreakoutFlow)
 

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.usi.core
 
-import akka.NotUsed
+import akka.Done
 import akka.stream.scaladsl.{Flow, GraphDSL, Keep}
 import akka.stream.{ActorMaterializer, FlowShape}
 import com.mesosphere.mesos.client.MesosCalls
@@ -13,20 +13,26 @@ import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEv
 import org.apache.mesos.v1.{Protos => Mesos}
 import org.scalatest._
 
+import scala.concurrent.Future
+
 class SchedulerTest extends AkkaUnitTest with Inside {
 
-  val loggingMockMesosFlow: Flow[MesosCall, MesosEvent, NotUsed] = Flow[MesosCall].map { call =>
-    logger.info(s"Mesos call: ${call}")
-    call
-  }.via(MesosMock.flow).map { event =>
-    logger.info(s"Mesos event: ${event}")
-    event
-  }
+  val loggingMockMesosFlow: Flow[MesosCall, MesosEvent, Future[Done]] = Flow[MesosCall]
+    .watchTermination()(Keep.right)
+    .map { call =>
+      logger.info(s"Mesos call: ${call}")
+      call
+    }
+    .via(MesosMock.flow)
+    .map { event =>
+      logger.info(s"Mesos event: ${event}")
+      event
+    }
 
-  val mockedScheduler: Flow[Scheduler.SpecInput, Scheduler.StateOutput, NotUsed] = {
+  def mockedScheduler: Flow[Scheduler.SpecInput, Scheduler.StateOutput, Future[Done]] = {
     Flow.fromGraph {
       GraphDSL.create(Scheduler.unconnectedGraph(new MesosCalls(MesosMock.mockFrameworkId)), loggingMockMesosFlow)(
-        (_, _) => NotUsed) { implicit builder =>
+        (_, materializedValue) => materializedValue) { implicit builder =>
         { (graph, mockMesos) =>
           import GraphDSL.Implicits._
 
@@ -73,5 +79,25 @@ class SchedulerTest extends AkkaUnitTest with Inside {
       case Some(podStatusChange: PodStatusUpdated) =>
         podStatusChange.newStatus.get.taskStatuses(TaskId(podId.value)).getState shouldBe Mesos.TaskState.TASK_RUNNING
     }
+  }
+
+  "It closes the Mesos client when the specs input stream terminates" in {
+    val ((input, mesosCompleted), _) = specInputSource(SpecsSnapshot.empty)
+      .viaMat(mockedScheduler)(Keep.both)
+      .toMat(outputFlatteningSink)(Keep.both)
+      .run
+
+    input.complete()
+    mesosCompleted.futureValue shouldBe Done
+  }
+
+  "It closes the Mesos client when the scheduler state events are closed" in {
+    val ((_, mesosCompleted), output) = specInputSource(SpecsSnapshot.empty)
+      .viaMat(mockedScheduler)(Keep.both)
+      .toMat(outputFlatteningSink)(Keep.both)
+      .run
+
+    output.cancel()
+    mesosCompleted.futureValue shouldBe Done
   }
 }


### PR DESCRIPTION
Prior to this change, the closing of one of the outputs would not affect the
other.

With this change, if the Mesos client closes, then the stream for the scheduler
state events will also be closed.

If the scheduler state events stream is closed, then the Mesos client is
closed.