### PR TITLE
Introduce validation through state updates

### DIFF
--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
@@ -18,6 +18,7 @@ case class PodSpec(id: PodId, goal: Goal, runSpec: RunSpec)
 
 object PodSpec {
   type ValidationMessage = String
+  val Valid = Seq.empty
 
   /**
     * Verifies that every value in range is requested only once. Requesting same value multiple times would yield pod that will never be scheduled.
@@ -33,7 +34,7 @@ object PodSpec {
     if (staticPorts.distinct.length != staticPorts.length) {
       Seq(s"Every value inside RangeResource can be requested only once. Requirement: ${staticPorts.mkString(",")}")
     } else {
-      Seq.empty
+      Valid
     }
   }
 
@@ -46,7 +47,7 @@ object PodSpec {
         .map(s => s"${s.resourceType}:${s.amount}")
         .mkString(",")}")
     } else {
-      Seq.empty
+      Valid
     }
   }
 

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/PodSpec.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.usi.core.models
 
+import com.mesosphere.usi.core.models.resources.{ExactValue, RangeRequirement, ResourceRequirement, ScalarRequirement}
+
 /**
   * Framework implementation owned specification of some Pod that should be launched.
   *
@@ -13,3 +15,45 @@ package com.mesosphere.usi.core.models
   * @param runSpec WIP the thing to run, and resource requirements, etc.
   */
 case class PodSpec(id: PodId, goal: Goal, runSpec: RunSpec)
+
+object PodSpec {
+  type ValidationMessage = String
+
+  /**
+    * Verifies that every value in range is requested only once. Requesting same value multiple times would yield pod that will never be scheduled.
+    * E.g. requesting two ports 80 on one machine is just not possible to satisfy
+    * @param runSpec runSpec we are validating
+    * @return true if provided range requirements are valid
+    */
+  private def validateStaticRangeRequirementsUnique(runSpec: RunSpec): Seq[ValidationMessage] = {
+    val staticPorts = runSpec.resourceRequirements.collect {
+      case RangeRequirement(requestedValues, _, _) => requestedValues
+    }.flatten.collect { case ExactValue(value) => value }
+
+    if (staticPorts.distinct.length != staticPorts.length) {
+      Seq(s"Every value inside RangeResource can be requested only once. Requirement: ${staticPorts.mkString(",")}")
+    } else {
+      Seq.empty
+    }
+  }
+
+  private def validateScalarRequirements(resourceRequirements: Seq[ResourceRequirement]): Seq[ValidationMessage] = {
+    val invalidScalar = resourceRequirements.collect {
+      case s: ScalarRequirement => s
+    }.filter(s => s.amount < 0)
+    if (invalidScalar.nonEmpty) {
+      Seq(s"Scalar values cannot be smaller than 0. Invalid requirements: ${invalidScalar
+        .map(s => s"${s.resourceType}:${s.amount}")
+        .mkString(",")}")
+    } else {
+      Seq.empty
+    }
+  }
+
+  def isValid(podSpec: PodSpec): Seq[ValidationMessage] = {
+    val uniqueRangeRequirements = validateStaticRangeRequirementsUnique(podSpec.runSpec)
+    val scalarRequirements = validateScalarRequirements(podSpec.runSpec.resourceRequirements)
+
+    uniqueRangeRequirements ++ scalarRequirements
+  }
+}

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -27,6 +27,7 @@ object StateSnapshot {
   */
 sealed trait StateUpdated extends StateEvent
 
+case class PodInvalid(id: PodId, errors: Seq[String]) extends StateUpdated with PodStateEvent
 case class PodStatusUpdated(id: PodId, newStatus: Option[PodStatus]) extends StateUpdated with PodStateEvent
 case class PodRecordUpdated(id: PodId, newRecord: Option[PodRecord]) extends StateUpdated with PodStateEvent
 case class AgentRecordUpdated(id: PodId, newRecord: Option[AgentRecord]) extends StateUpdated with PodStateEvent

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -28,7 +28,7 @@ object StateSnapshot {
 sealed trait StateUpdated extends StateEvent
 
 /**
-  * Captures a pod event that was caused by user of USI core submitting an invalid PodSpec.
+  * Captures a pod event that was caused by a [[SpecEvent]] submitted by the user.
   */
 sealed trait UserError extends PodStateEvent
 

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -27,7 +27,12 @@ object StateSnapshot {
   */
 sealed trait StateUpdated extends StateEvent
 
-case class PodInvalid(id: PodId, errors: Seq[String]) extends StateUpdated with PodStateEvent
+/**
+  * Captures a pod event that was caused by user of USI core submitting an invalid PodSpec.
+  */
+sealed trait UserError extends PodStateEvent
+
+case class PodInvalid(id: PodId, errors: Seq[String]) extends UserError
 case class PodStatusUpdated(id: PodId, newStatus: Option[PodStatus]) extends StateUpdated with PodStateEvent
 case class PodRecordUpdated(id: PodId, newRecord: Option[PodRecord]) extends StateUpdated with PodStateEvent
 case class AgentRecordUpdated(id: PodId, newRecord: Option[AgentRecord]) extends StateUpdated with PodStateEvent

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -95,9 +95,9 @@ object Scheduler {
   private val stateOutputBreakoutFlow: Flow[StateEvent, StateOutput, NotUsed] = Flow[StateEvent].prefixAndTail(0).map {
     case (_, stateEvents) =>
       val stateUpdates = stateEvents.map {
-        case c: StateUpdated => c
         case _: StateSnapshot =>
           throw new IllegalStateException("Only the first event is allowed to be a state snapshot")
+        case event => event
       }
       (StateSnapshot.empty, stateUpdates)
   }

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -4,9 +4,10 @@ import akka.NotUsed
 import akka.stream.scaladsl.{BidiFlow, Broadcast, Flow, GraphDSL, Source}
 import akka.stream.{BidiShape, FlowShape}
 import com.mesosphere.mesos.client.{MesosCalls, MesosClient}
-import com.mesosphere.usi.core.models.{SpecEvent, SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot, StateUpdated}
+import com.mesosphere.usi.core.models.{SpecEvent, SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot}
 import org.apache.mesos.v1.Protos.FrameworkInfo
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
+
 import scala.collection.JavaConverters._
 
 /*

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -2,7 +2,6 @@ package com.mesosphere.usi.core
 
 import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core.logic.{MesosEventsLogic, SpecLogic}
-import com.mesosphere.usi.core.models.PodSpec.ValidationMessage
 import com.mesosphere.usi.core.models.{PodId, PodInvalid, PodSpec, PodSpecUpdated, SpecEvent, SpecsSnapshot}
 import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -88,19 +88,11 @@ private[core] class SchedulerLogicHandler(mesosCallFactory: MesosCalls) {
 
   def validateEvent(msg: SpecEvent): Seq[PodInvalid] = msg match {
     case SpecsSnapshot(podSpecs, _) =>
-      podSpecs
-        .map(p => {
-          PodSpec.isValid(p) match {
-            case Nil => None
-            case err => Some(PodInvalid(p.id, err))
-          }
-        })
-        .collect { case Some(p) => p }
-    case PodSpecUpdated(_, Some(podSpec)) =>
-      PodSpec.isValid(podSpec) match {
-        case Nil => Seq.empty
-        case err => Seq(PodInvalid(podSpec.id, err))
+      podSpecs.flatMap { p =>
+        PodSpec.isValid(p).toList.map(err => PodInvalid(p.id, Seq(err)))
       }
+    case PodSpecUpdated(_, Some(podSpec)) =>
+      PodSpec.isValid(podSpec).toList.map(err => PodInvalid(podSpec.id, Seq(err)))
     case _ => Seq.empty
   }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -88,12 +88,14 @@ private[core] class SchedulerLogicHandler(mesosCallFactory: MesosCalls) {
 
   def validateEvent(msg: SpecEvent): Seq[PodInvalid] = msg match {
     case SpecsSnapshot(podSpecs, _) =>
-      podSpecs.map(p => {
-        PodSpec.isValid(p) match {
-          case Nil => None
-          case err => Some(PodInvalid(p.id, err))
-        }
-      }).collect { case Some (p) => p }
+      podSpecs
+        .map(p => {
+          PodSpec.isValid(p) match {
+            case Nil => None
+            case err => Some(PodInvalid(p.id, err))
+          }
+        })
+        .collect { case Some(p) => p }
     case PodSpecUpdated(_, Some(podSpec)) =>
       PodSpec.isValid(podSpec) match {
         case Nil => Seq.empty

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
@@ -38,6 +38,7 @@ case class SchedulerState(podRecords: Map[PodId, PodRecord], podStatuses: Map[Po
       case agentRecordChange: AgentRecordUpdated => ???
       case reservationStatusChange: ReservationStatusUpdated => ???
       case statusSnapshot: StateSnapshot => ???
+      case _: PodInvalid => ???
     }
 
     copy(podRecords = newPodRecords, podStatuses = newPodStatuses)


### PR DESCRIPTION
This is another possibility how to approach invalid PodSpecs that Tim prefers. Basically there are several ways how PodSpec can be invalid:
- it can request resources that would never be offered thus it will never be scheduled
- it can contain commands or networks that does not exist and it will always fail
- it can contain a configuration that we know upfront is invalid and we don't even need to push that podspec to offer matching

For all these cases we decided to use the same channel of communicating these errors back to framework and that's the StateEvents. 

PS: for now this is just a very rough PR without tests and some polishing until we agree this is the way we want to go.