### PR TITLE
Define Java DSL compatible Scheduler factory.

### DIFF
--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -9,7 +9,7 @@ import org.apache.mesos.v1.Protos.FrameworkInfo
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 import scala.collection.JavaConverters._
 
-/*
+/**
  * Provides the scheduler graph component. The component has two inputs, and two outputs:
  *
  * Input:

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -10,42 +10,42 @@ import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEv
 import scala.collection.JavaConverters._
 
 /**
- * Provides the scheduler graph component. The component has two inputs, and two outputs:
- *
- * Input:
- * 1) SpecInput - Used to replicate the specification state from the framework implementation to the USI SchedulerLogic;
- *    First, a spec snapshot, followed by spec updates.
- * 2) MesosEvents - Events from Mesos; offers, task status updates, etc.
- *
- * Output:
- * 1) StateEvents - Used to replicate the state of pods, agents, and reservations to the framework
- *    First, a scheduler state snapshot, followed by state updates.
- * 2) MesosCalls - Actions, such as revive, kill, accept offer, etc., used to realize the specification.
- *
- * Fully wired, the graph looks like this at a high-level view:
- *
- *                                                 *** SCHEDULER ***
- *                    +------------------------------------------------------------------------+
- *                    |                                                                        |
- *                    |  +------------------+           +-------------+        StateOutput     |
- *        SpecInput   |  |                  |           |             |     /------------------>----> (framework)
- * (framework) >------>-->                  | Scheduler |             |    /                   |
- *                    |  |                  |  Events   |             |   /                    |
- *                    |  |  SchedulerLogic  o-----------> Persistence o--+                     |
- *                    |  |                  |           |             |   \                    |
- *       MesosEvents  |  |                  |           |             |    \   MesosCalls      |
- *       /------------>-->                  |           |             |     \------------------>
- *      /             |  |                  |           |             |                        |\
- *     /              |  +------------------+           +-------------+                        | \
- *    /               |                                                                        |  \
- *   |                +------------------------------------------------------------------------+  |
- *    \                                                                                           |
- *     \                               +----------------------+                                  /
- *      \                              |                      |                                 /
- *       \-----------------------------<        Mesos         <---------------------------------
- *                                     |                      |
- *                                     +----------------------+
- */
+  * Provides the scheduler graph component. The component has two inputs, and two outputs:
+  *
+  * Input:
+  * 1) SpecInput - Used to replicate the specification state from the framework implementation to the USI SchedulerLogic;
+  *    First, a spec snapshot, followed by spec updates.
+  * 2) MesosEvents - Events from Mesos; offers, task status updates, etc.
+  *
+  * Output:
+  * 1) StateEvents - Used to replicate the state of pods, agents, and reservations to the framework
+  *    First, a scheduler state snapshot, followed by state updates.
+  * 2) MesosCalls - Actions, such as revive, kill, accept offer, etc., used to realize the specification.
+  *
+  * Fully wired, the graph looks like this at a high-level view:
+  *
+  *                                                 *** SCHEDULER ***
+  *                    +------------------------------------------------------------------------+
+  *                    |                                                                        |
+  *                    |  +------------------+           +-------------+        StateOutput     |
+  *        SpecInput   |  |                  |           |             |     /------------------>----> (framework)
+  * (framework) >------>-->                  | Scheduler |             |    /                   |
+  *                    |  |                  |  Events   |             |   /                    |
+  *                    |  |  SchedulerLogic  o-----------> Persistence o--+                     |
+  *                    |  |                  |           |             |   \                    |
+  *       MesosEvents  |  |                  |           |             |    \   MesosCalls      |
+  *       /------------>-->                  |           |             |     \------------------>
+  *      /             |  |                  |           |             |                        |\
+  *     /              |  +------------------+           +-------------+                        | \
+  *    /               |                                                                        |  \
+  *   |                +------------------------------------------------------------------------+  |
+  *    \                                                                                           |
+  *     \                               +----------------------+                                  /
+  *      \                              |                      |                                 /
+  *       \-----------------------------<        Mesos         <---------------------------------
+  *                                     |                      |
+  *                                     +----------------------+
+  */
 object Scheduler {
   type SpecInput = (SpecsSnapshot, Source[SpecUpdated, Any])
 

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -51,6 +51,9 @@ object Scheduler {
 
   type StateOutput = (StateSnapshot, Source[StateEvent, Any])
 
+  def fromSnapshot(specsSnapshot: SpecsSnapshot, client: MesosClient): Flow[SpecUpdated, StateOutput, NotUsed] =
+    Flow[SpecUpdated].prefixAndTail(0).map { case (_, rest) => specsSnapshot -> rest }.via(fromClient(client))
+
   def fromClient(client: MesosClient): Flow[SpecInput, StateOutput, NotUsed] = {
     if (!isMultiRoleFramework(client.frameworkInfo)) {
       throw new IllegalArgumentException(

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -35,7 +35,7 @@ object Scheduler {
   /**
     * Constructs a USI scheduler flow to managing pods.
     *
-    * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
+    * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]] of [[SpecInput]]. The output is a [[akka.japi.Pair]]
     * of [[StateSnapshot]] and [[javadsl.Source]] of [[StateOutput]].
     *
     * @param client The [[MesosClient]] used to interact with Mesos.

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -1,4 +1,4 @@
-package com.mesosphere.usi.core.javaapi
+package com.mesosphere.usi.core.japi
 
 import akka.NotUsed
 import akka.stream.javadsl
@@ -15,6 +15,22 @@ object Scheduler {
   type SpecInput = akka.japi.Pair[SpecsSnapshot, javadsl.Source[SpecUpdated, Any]]
 
   type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
+
+  /**
+    * Constructs a USI scheduler given an initial pod specs snapshot.
+    *
+    * @param specsSnapshot The initial snapshot of pod specs.
+    * @param client The [[MesosClient]] used to interact with Mesos.
+    * @return A [[javadsl]] flow from pod spec updates to state events.
+    */
+  def fromSnapshot(
+      specsSnapshot: SpecsSnapshot,
+      client: MesosClient): javadsl.Flow[SpecUpdated, StateOutput, NotUsed] = {
+    javadsl.Flow
+      .create[SpecUpdated]()
+      .via(ScalaScheduler.fromSnapshot(specsSnapshot, client))
+      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
+  }
 
   /**
     * Constructs a USI scheduler flow to managing pods.

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -36,7 +36,7 @@ object Scheduler {
     * Constructs a USI scheduler flow to managing pods.
     *
     * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
-    * of [[StateSnapshot]] and [[javadsl.Source]].
+    * of [[StateSnapshot]] and [[javadsl.Source]] of [[StateOutput]].
     *
     * @param client The [[MesosClient]] used to interact with Mesos.
     * @return A [[javadsl]] flow from pod specs to state events.

--- a/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
@@ -8,7 +8,7 @@ import com.mesosphere.usi.core.models.{SpecUpdated, SpecsSnapshot, StateEvent, S
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 
 /**
- *
+ * Java friendly factory methods of [[com.mesosphere.usi.core.Scheduler]].
  */
 object Scheduler {
 

--- a/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
@@ -1,0 +1,33 @@
+package com.mesosphere.usi.core.javaapi
+
+import akka.NotUsed
+import akka.stream.javadsl
+import com.mesosphere.mesos.client.{MesosCalls, MesosClient}
+import com.mesosphere.usi.core.{Scheduler => ScalaScheduler}
+import com.mesosphere.usi.core.models.{SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot}
+import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
+
+object Scheduler {
+
+  type SpecInput = akka.japi.Pair[SpecsSnapshot, javadsl.Source[SpecUpdated, Any]]
+
+  type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
+
+  def fromClient(client: MesosClient): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
+    javadsl.Flow
+      .create[SpecInput]()
+      .map(pair => pair.first -> pair.second.asScala)
+      .via(ScalaScheduler.fromClient(client))
+      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
+  }
+
+  def fromFlow(
+      mesosCallFactory: MesosCalls,
+      mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
+    javadsl.Flow
+      .create[SpecInput]()
+      .map(pair => pair.first -> pair.second.asScala)
+      .via(ScalaScheduler.fromFlow(mesosCallFactory, mesosFlow.asScala))
+      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
+  }
+}

--- a/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
@@ -13,6 +13,15 @@ object Scheduler {
 
   type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
 
+  /**
+    * Constructs a USI scheduler flow to managing pods.
+    *
+    * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
+    * of [[StateSnapshot]] and [[javadsl.Source]].
+    *
+    * @param client The [[MesosClient]] used to interact with Mesos.
+    * @return A [[javadsl]] flow from pod specs to state events.
+    */
   def fromClient(client: MesosClient): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
     javadsl.Flow
       .create[SpecInput]()
@@ -21,6 +30,15 @@ object Scheduler {
       .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
   }
 
+  /**
+    * Constructs a USI scheduler flow to managing pods.
+    *
+    * See [[Scheduler.fromClient()]] for a simpler constructor.
+    *
+    * @param mesosCallFactory A factory for construct [[MesosCall]]s.
+    * @param mesosFlow A flow from [[MesosCall]]s to [[MesosEvent]]s.
+    * @return A [[javadsl]] flow from pod specs to state events.
+    */
   def fromFlow(
       mesosCallFactory: MesosCalls,
       mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {

--- a/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
@@ -7,6 +7,9 @@ import com.mesosphere.usi.core.{Scheduler => ScalaScheduler}
 import com.mesosphere.usi.core.models.{SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot}
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 
+/**
+ *
+ */
 object Scheduler {
 
   type SpecInput = akka.japi.Pair[SpecsSnapshot, javadsl.Source[SpecUpdated, Any]]
@@ -14,14 +17,14 @@ object Scheduler {
   type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
 
   /**
-    * Constructs a USI scheduler flow to managing pods.
-    *
-    * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
-    * of [[StateSnapshot]] and [[javadsl.Source]].
-    *
-    * @param client The [[MesosClient]] used to interact with Mesos.
-    * @return A [[javadsl]] flow from pod specs to state events.
-    */
+   * Constructs a USI scheduler flow to managing pods.
+   *
+   * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
+   * of [[StateSnapshot]] and [[javadsl.Source]].
+   *
+   * @param client The [[MesosClient]] used to interact with Mesos.
+   * @return A [[javadsl]] flow from pod specs to state events.
+   */
   def fromClient(client: MesosClient): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
     javadsl.Flow
       .create[SpecInput]()
@@ -31,14 +34,14 @@ object Scheduler {
   }
 
   /**
-    * Constructs a USI scheduler flow to managing pods.
-    *
-    * See [[Scheduler.fromClient()]] for a simpler constructor.
-    *
-    * @param mesosCallFactory A factory for construct [[MesosCall]]s.
-    * @param mesosFlow A flow from [[MesosCall]]s to [[MesosEvent]]s.
-    * @return A [[javadsl]] flow from pod specs to state events.
-    */
+   * Constructs a USI scheduler flow to managing pods.
+   *
+   * See [[Scheduler.fromClient()]] for a simpler constructor.
+   *
+   * @param mesosCallFactory A factory for construct [[MesosCall]]s.
+   * @param mesosFlow A flow from [[MesosCall]]s to [[MesosEvent]]s.
+   * @return A [[javadsl]] flow from pod specs to state events.
+   */
   def fromFlow(
       mesosCallFactory: MesosCalls,
       mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {

--- a/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/javaapi/Scheduler.scala
@@ -8,8 +8,8 @@ import com.mesosphere.usi.core.models.{SpecUpdated, SpecsSnapshot, StateEvent, S
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 
 /**
- * Java friendly factory methods of [[com.mesosphere.usi.core.Scheduler]].
- */
+  * Java friendly factory methods of [[com.mesosphere.usi.core.Scheduler]].
+  */
 object Scheduler {
 
   type SpecInput = akka.japi.Pair[SpecsSnapshot, javadsl.Source[SpecUpdated, Any]]
@@ -17,14 +17,14 @@ object Scheduler {
   type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
 
   /**
-   * Constructs a USI scheduler flow to managing pods.
-   *
-   * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
-   * of [[StateSnapshot]] and [[javadsl.Source]].
-   *
-   * @param client The [[MesosClient]] used to interact with Mesos.
-   * @return A [[javadsl]] flow from pod specs to state events.
-   */
+    * Constructs a USI scheduler flow to managing pods.
+    *
+    * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]]. The output is a [[akka.japi.Pair]]
+    * of [[StateSnapshot]] and [[javadsl.Source]].
+    *
+    * @param client The [[MesosClient]] used to interact with Mesos.
+    * @return A [[javadsl]] flow from pod specs to state events.
+    */
   def fromClient(client: MesosClient): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
     javadsl.Flow
       .create[SpecInput]()
@@ -34,14 +34,14 @@ object Scheduler {
   }
 
   /**
-   * Constructs a USI scheduler flow to managing pods.
-   *
-   * See [[Scheduler.fromClient()]] for a simpler constructor.
-   *
-   * @param mesosCallFactory A factory for construct [[MesosCall]]s.
-   * @param mesosFlow A flow from [[MesosCall]]s to [[MesosEvent]]s.
-   * @return A [[javadsl]] flow from pod specs to state events.
-   */
+    * Constructs a USI scheduler flow to managing pods.
+    *
+    * See [[Scheduler.fromClient()]] for a simpler constructor.
+    *
+    * @param mesosCallFactory A factory for construct [[MesosCall]]s.
+    * @param mesosFlow A flow from [[MesosCall]]s to [[MesosEvent]]s.
+    * @return A [[javadsl]] flow from pod specs to state events.
+    */
   def fromFlow(
       mesosCallFactory: MesosCalls,
       mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {


### PR DESCRIPTION
Summary:
This patch defines a `akka.stream.javadsl` compatible `Scheduler` API. It roughly
follows the pattern from the `javadsl.Flow` implementation.

Blocks mesosphere/mesos-plugin#26.