### PR TITLE
Use InMemoryPersistenceStorage for persisting pod records

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: scala
 install:
   - true
 scala:
-   - 2.12.7
+  - 2.12.7
 script:
   - ./gradlew checkScalaFmtAll && sudo ./gradlew provision && ./gradlew ci --info
 before_cache:

--- a/core-models/src/main/resources/reference.conf
+++ b/core-models/src/main/resources/reference.conf
@@ -6,6 +6,8 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 
-persistence {
-  pipeline-limit = 128
+scheduler {
+  persistence {
+    pipeline-limit = 128
+  }
 }

--- a/core-models/src/main/resources/reference.conf
+++ b/core-models/src/main/resources/reference.conf
@@ -9,5 +9,6 @@ akka {
 scheduler {
   persistence {
     pipeline-limit = 128
+    load-timeout = 60 # seconds
   }
 }

--- a/core-models/src/main/resources/reference.conf
+++ b/core-models/src/main/resources/reference.conf
@@ -5,3 +5,7 @@ akka {
   loglevel = "INFO"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
+
+persistence {
+  pipeline-limit = 128
+}

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -12,10 +12,7 @@ sealed trait PodStateEvent extends StateEvent {
   def id: PodId
 }
 
-case class StateSnapshot(
-    podRecords: Seq[PodRecord],
-    agentRecords: Seq[AgentRecord])
-    extends StateEvent
+case class StateSnapshot(podRecords: Seq[PodRecord], agentRecords: Seq[AgentRecord]) extends StateEvent
 object StateSnapshot {
   def empty = StateSnapshot(Nil, Nil)
 }

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -13,13 +13,11 @@ sealed trait PodStateEvent extends StateEvent {
 }
 
 case class StateSnapshot(
-    podStatuses: Seq[PodStatus],
     podRecords: Seq[PodRecord],
-    agentRecords: Seq[AgentRecord],
-    reservationStatuses: Seq[ReservationStatus])
+    agentRecords: Seq[AgentRecord])
     extends StateEvent
 object StateSnapshot {
-  def empty = StateSnapshot(Nil, Nil, Nil, Nil)
+  def empty = StateSnapshot(Nil, Nil)
 }
 
 /**

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/StateEvent.scala
@@ -12,9 +12,9 @@ sealed trait PodStateEvent extends StateEvent {
   def id: PodId
 }
 
-case class StateSnapshot(podRecords: Seq[PodRecord], agentRecords: Seq[AgentRecord]) extends StateEvent
+case class StateSnapshot(podRecords: Seq[PodRecord] = Nil, agentRecords: Seq[AgentRecord] = Nil) extends StateEvent
 object StateSnapshot {
-  def empty = StateSnapshot(Nil, Nil)
+  val empty = StateSnapshot()
 }
 
 /**

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(':core-models')
+    compile project(':persistence')
     compile project(':mesos-client')
     testCompile project(':test-utils')
 }

--- a/core/src/main/scala/com/mesosphere/usi/core/CallerThreadExecutionContext.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/CallerThreadExecutionContext.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.Executor
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 
+// TODO : This is a duplicated in com.mesosphere.usi.async. Ideally, this needs to be in a shared module.
 private[usi] object CallerThreadExecutionContext {
   val executor: Executor = (command: Runnable) => command.run()
 

--- a/core/src/main/scala/com/mesosphere/usi/core/CallerThreadExecutionContext.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/CallerThreadExecutionContext.scala
@@ -1,0 +1,11 @@
+package com.mesosphere.usi.core
+
+import java.util.concurrent.Executor
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+
+private[usi] object CallerThreadExecutionContext {
+  val executor: Executor = (command: Runnable) => command.run()
+
+  implicit val context: ExecutionContextExecutor = ExecutionContext.fromExecutor(executor)
+}

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -1,13 +1,24 @@
 package com.mesosphere.usi.core
 
+import akka.Done
 import akka.NotUsed
 import akka.stream.scaladsl.{BidiFlow, Broadcast, Flow, GraphDSL, Source}
 import akka.stream.{BidiShape, FlowShape}
 import com.mesosphere.mesos.client.{MesosCalls, MesosClient}
-import com.mesosphere.usi.core.models.{SpecEvent, SpecUpdated, SpecsSnapshot, StateEvent, StateSnapshot, StateUpdated}
+import com.mesosphere.usi.core.models.{
+  PodRecordUpdated,
+  SpecEvent,
+  SpecUpdated,
+  SpecsSnapshot,
+  StateEvent,
+  StateSnapshot,
+  StateUpdated
+}
+import com.mesosphere.usi.repository.PodRecordRepository
 import org.apache.mesos.v1.Protos.FrameworkInfo
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 
 /*
  * Provides the scheduler graph component. The component has two inputs, and two outputs:
@@ -51,30 +62,33 @@ object Scheduler {
 
   type StateOutput = (StateSnapshot, Source[StateEvent, Any])
 
-  def fromClient(client: MesosClient): Flow[SpecInput, StateOutput, NotUsed] = {
+  def fromClient(
+      client: MesosClient,
+      podRecordRepository: PodRecordRepository
+  ): Flow[SpecInput, StateOutput, NotUsed] = {
     if (!isMultiRoleFramework(client.frameworkInfo)) {
       throw new IllegalArgumentException(
-        "USI scheduler provides support for MULTI_ROLE frameworks only. Please provide create MesosClient with FrameworkInfo that has capability MULTI_ROLE")
+        "USI scheduler provides support for MULTI_ROLE frameworks only. " +
+          "Please provide create MesosClient with FrameworkInfo that has capability MULTI_ROLE")
     }
-    fromFlow(client.calls, Flow.fromSinkAndSource(client.mesosSink, client.mesosSource))
+    fromFlow(client.calls, podRecordRepository, Flow.fromSinkAndSource(client.mesosSink, client.mesosSource))
   }
-
-  private def isMultiRoleFramework(frameworkInfo: FrameworkInfo): Boolean =
-    frameworkInfo.getCapabilitiesList.asScala.exists(_.getType == FrameworkInfo.Capability.Type.MULTI_ROLE)
 
   def fromFlow(
       mesosCallFactory: MesosCalls,
+      podRecordRepository: PodRecordRepository,
       mesosFlow: Flow[MesosCall, MesosEvent, Any]): Flow[SpecInput, StateOutput, NotUsed] = {
     Flow.fromGraph {
-      GraphDSL.create(unconnectedGraph(mesosCallFactory), mesosFlow)((_, _) => NotUsed) { implicit builder =>
-        { (graph, mesos) =>
-          import GraphDSL.Implicits._
+      GraphDSL.create(unconnectedGraph(mesosCallFactory, podRecordRepository), mesosFlow)((_, _) => NotUsed) {
+        implicit builder =>
+          { (graph, mesos) =>
+            import GraphDSL.Implicits._
 
-          mesos ~> graph.in2
-          graph.out2 ~> mesos
+            mesos ~> graph.in2
+            graph.out2 ~> mesos
 
-          FlowShape(graph.in1, graph.out1)
-        }
+            FlowShape(graph.in1, graph.out1)
+          }
       }
     }
   }
@@ -102,10 +116,14 @@ object Scheduler {
       (StateSnapshot.empty, stateUpdates)
   }
 
-  def unconnectedGraph(
-      mesosCallFactory: MesosCalls): BidiFlow[SpecInput, StateOutput, MesosEvent, MesosCall, NotUsed] = {
+  private[core] def unconnectedGraph(
+      mesosCallFactory: MesosCalls,
+      podRecordRepository: PodRecordRepository
+  ): BidiFlow[SpecInput, StateOutput, MesosEvent, MesosCall, NotUsed] = {
     BidiFlow.fromGraph {
-      GraphDSL.create(new SchedulerLogicGraph(mesosCallFactory)) { implicit builder => (schedulerLogic) =>
+      GraphDSL.create(
+        new SchedulerLogicGraph(mesosCallFactory, podRecordRepository.readAll()),
+      ) { implicit builder => (schedulerLogic) =>
         {
           import GraphDSL.Implicits._
 
@@ -113,8 +131,9 @@ object Scheduler {
           val specInputFlattening = builder.add(specInputFlatteningFlow)
           val stateOutputBreakout = builder.add(stateOutputBreakoutFlow)
 
+          val persistenceStorageFlow = builder.add(persistenceFlow(podRecordRepository))
           specInputFlattening ~> schedulerLogic.in0
-          schedulerLogic.out ~> broadcast.in
+          schedulerLogic.out ~> persistenceStorageFlow ~> broadcast.in
 
           val mesosCalls = broadcast.out(0).mapConcat { frameResult =>
             frameResult.mesosCalls
@@ -130,4 +149,25 @@ object Scheduler {
       }
     }
   }
+
+  private def persistenceFlow(
+      podRecordRepository: PodRecordRepository): Flow[SchedulerEvents, SchedulerEvents, NotUsed] =
+    Flow[SchedulerEvents].mapAsync(1) { events =>
+      import CallerThreadExecutionContext.context
+      Future
+        .sequence(events.stateEvents.map {
+          case _ @PodRecordUpdated(podId, maybePodRecord) =>
+            maybePodRecord match {
+              case Some(podRecord) =>
+                podRecordRepository.store(podRecord)
+              case None =>
+                podRecordRepository.delete(podId)
+            }
+          case _ => Future.successful(Done)
+        })
+        .map(_ => events)
+    }
+
+  private def isMultiRoleFramework(frameworkInfo: FrameworkInfo): Boolean =
+    frameworkInfo.getCapabilitiesList.asScala.exists(_.getType == FrameworkInfo.Capability.Type.MULTI_ROLE)
 }

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -64,8 +64,7 @@ object Scheduler {
 
   def fromClient(
       client: MesosClient,
-      podRecordRepository: PodRecordRepository
-  ): Flow[SpecInput, StateOutput, NotUsed] = {
+      podRecordRepository: PodRecordRepository): Flow[SpecInput, StateOutput, NotUsed] = {
     if (!isMultiRoleFramework(client.frameworkInfo)) {
       throw new IllegalArgumentException(
         "USI scheduler provides support for MULTI_ROLE frameworks only. " +
@@ -118,8 +117,7 @@ object Scheduler {
 
   private[core] def unconnectedGraph(
       mesosCallFactory: MesosCalls,
-      podRecordRepository: PodRecordRepository
-  ): BidiFlow[SpecInput, StateOutput, MesosEvent, MesosCall, NotUsed] = {
+      podRecordRepository: PodRecordRepository): BidiFlow[SpecInput, StateOutput, MesosEvent, MesosCall, NotUsed] = {
     BidiFlow.fromGraph {
       GraphDSL.create(
         new SchedulerLogicGraph(mesosCallFactory, podRecordRepository.readAll()),

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -2,8 +2,7 @@ package com.mesosphere.usi.core
 
 import akka.Done
 import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.{BidiShape, FlowShape}
+import akka.stream.{BidiShape, FlowShape, Materializer}
 import akka.stream.scaladsl.{BidiFlow, Broadcast, Flow, GraphDSL, Sink, Source}
 import com.mesosphere.mesos.client.{MesosCalls, MesosClient}
 import com.mesosphere.usi.core.models.{

--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -318,7 +318,7 @@ object Scheduler {
    * Block for IO - If the IO call fails or a timeout occurs, we should not make any progress.
    */
   private def loadPodRecords(podRecordRepository: PodRecordRepository): Map[PodId, PodRecord] = {
-    // Add better error handling (and maybe a retry mechanism).
+    // Add error handling (and maybe a retry mechanism).
     Await.result(podRecordRepository.readAll(), schedulerSettings.persistenceLoadTimeout.seconds)
   }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -88,7 +88,7 @@ private[core] class SchedulerLogicGraph(
 
       val startGraph = this.getAsyncCallback[Try[Map[PodId, PodRecord]]] {
         case Success(initialSnapshot) =>
-          handler.loadInitialPodRecords(initialSnapshot)
+          pushOrQueueIntents(handler.handlePodRecordSnapshot(initialSnapshot))
           maybePull()
         case Failure(ex) =>
           this.failStage(ex)

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -44,7 +44,7 @@ object SchedulerLogicGraph {
   */
 private[core] class SchedulerLogicGraph(
     mesosCallFactory: MesosCalls,
-    initialPodRecords: => Future[Map[PodId, PodRecord]])
+    initialPodRecords: () => Future[Map[PodId, PodRecord]])
     extends GraphStage[FanInShape2[SpecEvent, MesosEvent, SchedulerEvents]] {
   import SchedulerLogicGraph.BUFFER_SIZE
 
@@ -107,7 +107,7 @@ private[core] class SchedulerLogicGraph(
        * This code delays the starting of the scheduler stage until this podRecord snapshot is available.
        */
       override def preStart(): Unit =
-        initialPodRecords.onComplete(startGraph.invoke)(CallerThreadExecutionContext.context)
+        initialPodRecords().onComplete(startGraph.invoke)(CallerThreadExecutionContext.context)
 
       def pushOrQueueIntents(effects: SchedulerEvents): Unit = {
         if (isAvailable(frameResultOutlet)) {

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -1,19 +1,13 @@
 package com.mesosphere.usi.core
 
-import akka.stream.FanInShape2
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
-import akka.stream.{Attributes, Inlet, Outlet}
+import akka.stream.{Attributes, FanInShape2, Inlet, Outlet}
 import com.mesosphere.mesos.client.MesosCalls
-import com.mesosphere.usi.core.models.PodId
-import com.mesosphere.usi.core.models.PodRecord
-import com.mesosphere.usi.core.models.SpecEvent
-import com.typesafe.scalalogging.StrictLogging
+import com.mesosphere.usi.core.models.{PodId, PodRecord, SpecEvent}
 import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
 import scala.collection.mutable
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object SchedulerLogicGraph {
   val BUFFER_SIZE = 32
@@ -51,8 +45,7 @@ object SchedulerLogicGraph {
 private[core] class SchedulerLogicGraph(
     mesosCallFactory: MesosCalls,
     initialPodRecords: => Future[Map[PodId, PodRecord]])
-    extends GraphStage[FanInShape2[SpecEvent, MesosEvent, SchedulerEvents]]
-    with StrictLogging {
+    extends GraphStage[FanInShape2[SpecEvent, MesosEvent, SchedulerEvents]] {
   import SchedulerLogicGraph.BUFFER_SIZE
 
   private val mesosEventsInlet = Inlet[MesosEvent]("mesos-events")

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -94,6 +94,7 @@ private[core] class SchedulerLogicGraph(
           this.failStage(ex)
       }
 
+      // This will be removed if/when we refactor the code to not receive snapshot's anymore.
       override def preStart(): Unit =
         initialPodRecords.onComplete(startGraph.invoke)(CallerThreadExecutionContext.context)
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -96,7 +96,8 @@ private[core] class SchedulerLogicGraph(
       val startGraph = this.getAsyncCallback[Try[Map[PodId, PodRecord]]] {
         case Success(podRecords) =>
           handler = new SchedulerLogicHandler(mesosCallFactory, podRecords)
-          pushOrQueueIntents(SchedulerEvents(stateEvents = List(StateSnapshot.empty.copy(podRecords = podRecords.values.toSeq))))
+          pushOrQueueIntents(
+            SchedulerEvents(stateEvents = List(StateSnapshot.empty.copy(podRecords = podRecords.values.toSeq))))
           maybePull()
         case Failure(ex) =>
           this.failStage(ex)

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicGraph.scala
@@ -5,7 +5,6 @@ import akka.stream.{Attributes, FanInShape2, Inlet, Outlet}
 import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core.models.{PodId, PodRecord, SpecEvent, StateSnapshot}
 import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
-
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -129,11 +129,7 @@ private[core] class SchedulerLogicHandler(mesosCallFactory: MesosCalls) {
   def handlePodRecordSnapshot(podRecords: Map[PodId, PodRecord]): SchedulerEvents = {
     handleFrame { builder =>
       builder.process { (specs, state, _) =>
-        if (state.podRecords.nonEmpty || specs.podSpecs.nonEmpty) {
-          throw new IllegalStateException(
-            s"Expected initial Scheduler state to be empty." +
-              s" Found ${state.podRecords.size} records and ${specs.podSpecs.size} statuses")
-        }
+        require(state.podRecords.isEmpty && specs.podSpecs.isEmpty)
         SchedulerEvents(stateEvents = List(StateSnapshot.empty.copy(podRecords = podRecords.values.toSeq)))
       }
     }

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -2,6 +2,7 @@ package com.mesosphere.usi.core
 
 import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core.logic.{MesosEventsLogic, SpecLogic}
+import com.mesosphere.usi.core.models.PodRecord
 import com.mesosphere.usi.core.models.{PodId, SpecEvent}
 import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
 
@@ -84,6 +85,15 @@ private[core] class SchedulerLogicHandler(mesosCallFactory: MesosCalls) {
     * frame based on podIds becoming dirty.
     */
   private var cachedPendingLaunch = CachedPendingLaunch(Set.empty)
+
+  def loadInitialPodRecords(podRecords: Map[PodId, PodRecord]): Unit = {
+    if (state.podStatuses.nonEmpty) {
+      throw new IllegalStateException(
+        s"Expected initial Scheduler state to be empty." +
+          s" Found ${state.podRecords.size} records and ${state.podStatuses.size} statuses")
+    }
+    state = state.copy(podRecords)
+  }
 
   def handleSpecEvent(msg: SpecEvent): SchedulerEvents = {
     handleFrame { builder =>

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
@@ -38,10 +38,9 @@ case class SchedulerState(podRecords: Map[PodId, PodRecord], podStatuses: Map[Po
       case agentRecordChange: AgentRecordUpdated => ???
       case reservationStatusChange: ReservationStatusUpdated => ???
       case statusSnapshot: StateSnapshot =>
-        if (statusSnapshot.podRecords.nonEmpty) {
-          newPodRecords = statusSnapshot.podRecords
-            .foldLeft(newPodRecords)((acc, record) => acc.updated(record.podId, record))
-        }
+        // TODO (DCOS-47476) Implement cache invalidation and handle snapshot fully
+        newPodRecords = statusSnapshot.podRecords
+          .foldLeft(newPodRecords)((acc, record) => acc.updated(record.podId, record))
     }
 
     copy(podRecords = newPodRecords, podStatuses = newPodStatuses)

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
@@ -37,7 +37,11 @@ case class SchedulerState(podRecords: Map[PodId, PodRecord], podStatuses: Map[Po
         }
       case agentRecordChange: AgentRecordUpdated => ???
       case reservationStatusChange: ReservationStatusUpdated => ???
-      case statusSnapshot: StateSnapshot => ???
+      case statusSnapshot: StateSnapshot =>
+        if (statusSnapshot.podRecords.nonEmpty) {
+          newPodRecords = statusSnapshot.podRecords
+            .foldLeft(newPodRecords)((acc, record) => acc.updated(record.podId, record))
+        }
     }
 
     copy(podRecords = newPodRecords, podStatuses = newPodStatuses)

--- a/core/src/main/scala/com/mesosphere/usi/core/conf/SchedulerSettings.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/conf/SchedulerSettings.scala
@@ -2,11 +2,13 @@ package com.mesosphere.usi.core.conf
 
 import com.typesafe.config.Config
 
-case class SchedulerSettings(persistencePipelineLimit: Int)
+case class SchedulerSettings(persistencePipelineLimit: Int, persistenceLoadTimeout: Int)
 
 object SchedulerSettings {
   def fromConfig(schedulerConf: Config): SchedulerSettings = {
-    val persistencePipelineLimit = schedulerConf.getInt("persistence.pipeline-limit")
-    SchedulerSettings(persistencePipelineLimit)
+    val persistenceConf = schedulerConf.getConfig("persistence")
+    val persistencePipelineLimit = persistenceConf.getInt("pipeline-limit")
+    val persistenceLoadTimeout = persistenceConf.getInt("load-timeout")
+    SchedulerSettings(persistencePipelineLimit, persistenceLoadTimeout)
   }
 }

--- a/core/src/main/scala/com/mesosphere/usi/core/conf/SchedulerSettings.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/conf/SchedulerSettings.scala
@@ -1,0 +1,12 @@
+package com.mesosphere.usi.core.conf
+
+import com.typesafe.config.Config
+
+case class SchedulerSettings(persistencePipelineLimit: Int)
+
+object SchedulerSettings {
+  def fromConfig(schedulerConf: Config): SchedulerSettings = {
+    val persistencePipelineLimit = schedulerConf.getInt("persistence.pipeline-limit")
+    SchedulerSettings(persistencePipelineLimit)
+  }
+}

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -24,24 +24,6 @@ object Scheduler {
   type StateOutput = akka.japi.Pair[StateSnapshot, javadsl.Source[StateEvent, Any]]
 
   /**
-    * Constructs a USI scheduler given an initial pod specs snapshot.
-    *
-    * @param specsSnapshot The initial snapshot of pod specs.
-    * @param client The [[MesosClient]] used to interact with Mesos.
-    * @return A [[javadsl]] flow from pod spec updates to state events.
-    */
-  def fromSnapshot(
-      specsSnapshot: SpecsSnapshot,
-      client: MesosClient,
-      podRecordRepository: PodRecordRepository): javadsl.Flow[SpecUpdated, StateOutput, NotUsed] = {
-    scaladsl
-      .Flow[SpecUpdated]
-      .via(ScalaScheduler.fromSnapshot(specsSnapshot, client, podRecordRepository))
-      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
-      .asJava
-  }
-
-  /**
     * Constructs a USI scheduler flow to managing pods.
     *
     * The input is a [[akka.japi.Pair]] of [[SpecsSnapshot]] and [[javadsl.Source]] of [[SpecInput]]. The output is a [[akka.japi.Pair]]

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -30,13 +30,14 @@ object Scheduler {
     * @param client The [[MesosClient]] used to interact with Mesos.
     * @return A [[javadsl]] flow from pod spec updates to state events.
     */
-  def fromSnapshot(specsSnapshot: SpecsSnapshot, client: MesosClient, podRecordRepository: PodRecordRepository)(
-      mat: Materializer): javadsl.Flow[SpecUpdated, StateOutput, NotUsed] = {
-
-    scaladsl.Flow[SpecUpdated]
+  def fromSnapshot(
+      specsSnapshot: SpecsSnapshot,
+      client: MesosClient,
+      podRecordRepository: PodRecordRepository): javadsl.Flow[SpecUpdated, StateOutput, NotUsed] = {
+    scaladsl
+      .Flow[SpecUpdated]
       .via(ScalaScheduler.fromSnapshot(specsSnapshot, client, podRecordRepository))
-      .map {
-        case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
+      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
       .asJava
   }
 
@@ -51,9 +52,9 @@ object Scheduler {
     */
   def fromClient(
       client: MesosClient,
-      podRecordRepository: PodRecordRepository
-  )(mat: Materializer): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
-    scaladsl.Flow[SpecInput]
+      podRecordRepository: PodRecordRepository): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
+    scaladsl
+      .Flow[SpecInput]
       .map(pair => pair.first -> pair.second.asScala)
       .via(ScalaScheduler.fromClient(client, podRecordRepository))
       .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
@@ -72,14 +73,13 @@ object Scheduler {
   def fromFlow(
       mesosCallFactory: MesosCalls,
       podRecordRepository: PodRecordRepository,
-      mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]
-  )(mat: Materializer): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
-    scaladsl.Flow[SpecInput]
+      mesosFlow: javadsl.Flow[MesosCall, MesosEvent, Any]): javadsl.Flow[SpecInput, StateOutput, NotUsed] = {
+    scaladsl
+      .Flow[SpecInput]
       .map(pair => pair.first -> pair.second.asScala)
       .via(ScalaScheduler.fromFlow(mesosCallFactory, podRecordRepository, mesosFlow.asScala))
-      .map { case (taken, tail) =>
-        akka.japi.Pair(taken, tail.asJava)
-      }.asJava
+      .map { case (taken, tail) => akka.japi.Pair(taken, tail.asJava) }
+      .asJava
   }
 
   /**

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -1,0 +1,16 @@
+akka {
+  stream {
+    materializer {
+      debug {
+        # Enables the fuzzing mode which increases the chance of race conditions
+        # by aggressively reordering events and making certain operations more
+        # concurrent than usual.
+        # This setting is for testing purposes, NEVER enable this in a production
+        # environment!
+        # To get the best results, try combining this setting with a throughput
+        # of 1 on the corresponding dispatchers.
+        fuzzing-mode = on
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerFactoryTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerFactoryTest.scala
@@ -58,7 +58,7 @@ class SchedulerFactoryTest extends AkkaUnitTest with Inside {
         val (snapshotF, _, _) = Scheduler.asSourceAndSink(SpecsSnapshot.empty, scheduler)
         specInputQueue.pull().futureValue
 
-        val stateSnapshot = StateSnapshot(List(PodStatus(podSpec.id, Map.empty)), Nil)
+        val stateSnapshot = StateSnapshot(Nil, Nil)
 
         stateOutputQueue.offer(stateSnapshot -> Source.maybe)
 

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerFactoryTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerFactoryTest.scala
@@ -58,7 +58,7 @@ class SchedulerFactoryTest extends AkkaUnitTest with Inside {
         val (snapshotF, _, _) = Scheduler.asSourceAndSink(SpecsSnapshot.empty, scheduler)
         specInputQueue.pull().futureValue
 
-        val stateSnapshot = StateSnapshot(List(PodStatus(podSpec.id, Map.empty)), Nil, Nil, Nil)
+        val stateSnapshot = StateSnapshot(List(PodStatus(podSpec.id, Map.empty)), Nil)
 
         stateOutputQueue.offer(stateSnapshot -> Source.maybe)
 

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerLogicHandlerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerLogicHandlerTest.scala
@@ -9,7 +9,7 @@ import com.mesosphere.utils.UnitTest
 class SchedulerLogicHandlerTest extends UnitTest {
   "produce a Mesos call with revive for new podspec role" in {
     Given("Scheduler logic handler with empty state")
-    val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId))
+    val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), Map.empty)
     val podId = PodId("pod")
 
     When("pod with role 'test-role' is updated")
@@ -28,7 +28,7 @@ class SchedulerLogicHandlerTest extends UnitTest {
 
   "produce a mesos call with suppress when all podspecs for that roles were launched" in {
     Given("Scheduler logic handler with not launched pod")
-    val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId))
+    val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), Map.empty)
     val podId = PodId("pod")
     // creates not launched pod in the internal state of scheduler logic
     handler.handleSpecEvent(

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -112,7 +112,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
       val rand = scala.util.Random
       override def store(record: PodRecord): Future[Done] = {
         super.store(record).flatMap { _ =>
-          akka.pattern.after(rand.nextInt(1000).millis, system.scheduler)(Future.successful(Done))
+          akka.pattern.after(rand.nextInt(100).millis, system.scheduler)(Future.successful(Done))
         }
       }
     }

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -8,11 +8,11 @@ import com.mesosphere.usi.core.helpers.MesosMock
 import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.{outputFlatteningSink, specInputSource}
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.ScalarRequirement
+import com.mesosphere.usi.repository.InMemoryPodRecordRepository
 import com.mesosphere.utils.AkkaUnitTest
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 import org.apache.mesos.v1.{Protos => Mesos}
 import org.scalatest._
-
 import scala.concurrent.Future
 
 class SchedulerTest extends AkkaUnitTest with Inside {
@@ -31,8 +31,9 @@ class SchedulerTest extends AkkaUnitTest with Inside {
 
   def mockedScheduler: Flow[Scheduler.SpecInput, Scheduler.StateOutput, Future[Done]] = {
     Flow.fromGraph {
-      GraphDSL.create(Scheduler.unconnectedGraph(new MesosCalls(MesosMock.mockFrameworkId)), loggingMockMesosFlow)(
-        (_, materializedValue) => materializedValue) { implicit builder =>
+      GraphDSL.create(
+        Scheduler.unconnectedGraph(new MesosCalls(MesosMock.mockFrameworkId), new InMemoryPodRecordRepository),
+        loggingMockMesosFlow)((_, materializedValue) => materializedValue) { implicit builder =>
         { (graph, mockMesos) =>
           import GraphDSL.Implicits._
 

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -128,6 +128,9 @@ class SchedulerTest extends AkkaUnitTest with Inside {
 
     Then("flow should pipeline writes pulling only one element at a time")
     pub.sendNext(deleteOp)
+    pub.sendNext(deleteOp)
+    assertThrows[AssertionError](sub.expectNext(delayPerElement / 2))
+    sub.requestNext(deleteOp)
     assertThrows[AssertionError](sub.expectNext(delayPerElement / 2))
     sub.requestNext(deleteOp)
 

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -32,7 +32,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
   def mockedScheduler: Flow[Scheduler.SpecInput, Scheduler.StateOutput, Future[Done]] = {
     Flow.fromGraph {
       GraphDSL.create(
-        Scheduler.unconnectedGraph(new MesosCalls(MesosMock.mockFrameworkId), new InMemoryPodRecordRepository),
+        Scheduler.unconnectedGraph(new MesosCalls(MesosMock.mockFrameworkId), InMemoryPodRecordRepository()),
         loggingMockMesosFlow)((_, materializedValue) => materializedValue) { implicit builder =>
         { (graph, mockMesos) =>
           import GraphDSL.Implicits._

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -10,8 +10,8 @@ import com.mesosphere.usi.core.helpers.MesosMock
 import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.{outputFlatteningSink, specInputSource}
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.ScalarRequirement
-import com.mesosphere.usi.repository.InMemoryPodRecordRepository
 import com.mesosphere.utils.AkkaUnitTest
+import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import com.typesafe.config.ConfigFactory
 import java.time.Instant
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -5,12 +5,14 @@ import akka.stream.scaladsl.{Flow, GraphDSL, Keep}
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.stream.{ActorMaterializer, FlowShape}
 import com.mesosphere.mesos.client.MesosCalls
+import com.mesosphere.usi.core.conf.SchedulerSettings
 import com.mesosphere.usi.core.helpers.MesosMock
 import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.{outputFlatteningSink, specInputSource}
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.ScalarRequirement
 import com.mesosphere.usi.repository.InMemoryPodRecordRepository
 import com.mesosphere.utils.AkkaUnitTest
+import com.typesafe.config.ConfigFactory
 import java.time.Instant
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 import org.apache.mesos.v1.{Protos => Mesos}
@@ -146,7 +148,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
 
   "Persistence flow honors the pipe-lining threshold" in {
     Given("a list of persistence operations with count strictly greater than twice the pipeline limit")
-    val limit = Scheduler.PipeliningLimit
+    val limit = SchedulerSettings.fromConfig(ConfigFactory.load().getConfig("scheduler")).persistencePipelineLimit
     val deleteEvents = (1 to limit * 2 + 1)
       .map(x => PodRecordUpdated(PodId("pod-" + x), None))
       .grouped(100)

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -122,7 +122,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
       .toMat(TestSink.probe[SchedulerEvents])(Keep.both)
       .run()
 
-    Given("a list of fake pod record events")
+    And("a list of fake pod record events")
     val podIds = List(List("A", "B"), List("C", "D"), List("E", "F")).map(_.map(PodId))
     val storesAndDeletes = podIds.flatMap { ids =>
       val storeEvents = ids.map(id => PodRecordUpdated(id, Some(PodRecord(id, Instant.now(), AgentId("-")))))

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -8,6 +8,7 @@ import com.mesosphere.usi.core.Scheduler
 import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.{outputFlatteningSink, specInputSource}
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.{RangeRequirement, ScalarRequirement}
+import com.mesosphere.usi.repository.InMemoryPodRecordRepository
 import com.mesosphere.utils.AkkaUnitTest
 import com.mesosphere.utils.mesos.MesosClusterTest
 import org.apache.mesos.v1.Protos
@@ -27,7 +28,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
     .build()
 
   lazy val mesosClient: MesosClient = MesosClient(settings, frameworkInfo).runWith(Sink.head).futureValue
-  lazy val schedulerFlow = Scheduler.fromClient(mesosClient)
+  lazy val schedulerFlow = Scheduler.fromClient(mesosClient, new InMemoryPodRecordRepository)
   lazy val (input, output) = specInputSource(SpecsSnapshot.empty)
     .via(schedulerFlow)
     .toMat(outputFlatteningSink)(Keep.both)

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -28,7 +28,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
     .build()
 
   lazy val mesosClient: MesosClient = MesosClient(settings, frameworkInfo).runWith(Sink.head).futureValue
-  lazy val schedulerFlow = Scheduler.fromClient(mesosClient, new InMemoryPodRecordRepository)
+  lazy val schedulerFlow = Scheduler.fromClient(mesosClient, InMemoryPodRecordRepository())
   lazy val (input, output) = specInputSource(SpecsSnapshot.empty)
     .via(schedulerFlow)
     .toMat(outputFlatteningSink)(Keep.both)

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -8,9 +8,9 @@ import com.mesosphere.usi.core.Scheduler
 import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.{outputFlatteningSink, specInputSource}
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.{RangeRequirement, ScalarRequirement}
-import com.mesosphere.usi.repository.InMemoryPodRecordRepository
 import com.mesosphere.utils.AkkaUnitTest
 import com.mesosphere.utils.mesos.MesosClusterTest
+import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.Protos
 import org.apache.mesos.v1.Protos.FrameworkInfo
 import org.scalatest.Inside

--- a/examples/core-hello-world/build.gradle
+++ b/examples/core-hello-world/build.gradle
@@ -9,6 +9,8 @@ application {
 dependencies {
     implementation project(':core')
     implementation project(':persistence')
-    testCompile project(':test-utils')
+
+    // Use testCompile when we add implementation project(':persistence-zookeeper')
+    implementation project(':test-utils')
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }

--- a/examples/core-hello-world/build.gradle
+++ b/examples/core-hello-world/build.gradle
@@ -8,6 +8,8 @@ application {
 
 dependencies {
     implementation project(':core')
+    implementation project(':persistence')
+    implementation project(':metrics')
     testCompile project(':test-utils')
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }

--- a/examples/core-hello-world/build.gradle
+++ b/examples/core-hello-world/build.gradle
@@ -9,7 +9,6 @@ application {
 dependencies {
     implementation project(':core')
     implementation project(':persistence')
-    implementation project(':metrics')
     testCompile project(':test-utils')
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -110,7 +110,7 @@ object CoreHelloWorldFramework extends StrictLogging {
       .setName("CoreHelloWorldExample")
       .addRoles("test")
       .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
-      .setFailoverTimeout(1d)
+      .setFailoverTimeout(0d)
       .build()
   }
 

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -1,11 +1,11 @@
 package com.mesosphere.usi.examples
 
+import akka.Done
 import java.util.UUID
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.{ActorMaterializer, KillSwitch}
+import akka.stream.{ActorMaterializer, KillSwitch, Materializer}
 import com.mesosphere.mesos.client.MesosClient
 import com.mesosphere.mesos.conf.MesosClientSettings
 import com.mesosphere.usi.core.Scheduler
@@ -22,14 +22,15 @@ import com.mesosphere.usi.core.models.{
   StateEvent,
   StateSnapshot
 }
+import com.mesosphere.usi.repository.{InMemoryPodRecordRepository, PodRecordRepository}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.Protos.{FrameworkID, FrameworkInfo, TaskState, TaskStatus}
-
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.sys.SystemProperties
-import scala.util.{Failure, Success}
+import scala.util.Failure
+import scala.util.Success
 
 /**
   * Run the hello-world example framework that:
@@ -42,15 +43,54 @@ import scala.util.{Failure, Success}
   *  Good to test against local Mesos.
   *
   */
-case class CoreHelloWorldFramework(frameworkId: FrameworkID, killSwitch: KillSwitch)
+case class CoreHelloWorldFramework(frameworkId: FrameworkID, killSwitch: KillSwitch, result: Future[Done])
 
 object CoreHelloWorldFramework extends StrictLogging {
 
+  /**
+    * The type of [[SchedulerFlow]] might look scary at the first glance (and sometimes even at second) but it is
+    * at the core (!) of any framework. Basically it is a Flow that [[SpecUpdated]] events as input and produces
+    * [[StateEvent]] as an output.
+    *
+    * +--------------------+         +-----------------------+        +-----------------------+
+    * |                    |         |                       |        |                       |
+    * |     SpecUpdated    |         |                       |        |      StateEvent       |
+    * |                    +--------->  Core SchedulerFlow   +-------->                       |
+    * |   new and updated  |         |                       |        | replicated Pod, Agent |
+    * |       PodSpecs     |         |                       |        | and Reservations state|
+    * +--------------------+         +-----------------------+        +-----------------------+
+    *
+    *
+    * In a nutshell: frameworks sends [[PodSpec]] updates down the flow and receives [[StateEvent]]s when things
+    * change. So why is the input parameter of that Flow not simply a [[SpecUpdated]] but a tuple of
+    * [[SpecsSnapshot]] and Source[[SpecUpdated]]? This is because the first message sent to the scheduler
+    * by the framework should be a snapshot of all PodSpecs known to the framework - a [[SpecsSnapshot]]. Internally
+    * this will trigger [task reconciliation](http://mesos.apache.org/documentation/latest/reconciliation/) by the
+    * scheduler.
+    *
+    * The same logic applies for the output parameter of the scheduler Flow - it's a tuple of [[StateSnapshot]] and a
+    * Source of [[StateEvent]], which means that the first state event received by the framework will be a
+    * snapshot of all reconciled tasks states, followed by a individual updates.
+    *
+    * For more about the scheduler flow see [[Scheduler]] class documentation.
+    *
+    */
+  type SchedulerFlow =
+    Flow[(SpecsSnapshot, Source[SpecUpdated, Any]), (StateSnapshot, Source[StateEvent, Any]), NotUsed]
+
   def main(args: Array[String]): Unit = {
     implicit val actorSystem = ActorSystem()
+    implicit val ec = actorSystem.dispatcher
     val conf = ConfigFactory.load().getConfig("mesos-client")
     try {
-      run(conf)
+      run(conf).result.onComplete {
+        case Success(res) =>
+          logger.info(s"Stream completed: $res");
+          actorSystem.terminate()
+        case Failure(e) =>
+          logger.error(s"Error in stream: $e");
+          actorSystem.terminate()
+      }
     } catch {
       case ex: Throwable =>
         System.err.println(s"Exception while starting framework! ${ex}")
@@ -60,12 +100,8 @@ object CoreHelloWorldFramework extends StrictLogging {
     }
   }
 
-  def run(conf: Config)(implicit system: ActorSystem): CoreHelloWorldFramework = {
-    implicit val mat = ActorMaterializer()
-    implicit val ec = system.dispatcher
-
-    val settings = MesosClientSettings(conf.getString("master-url"))
-    val frameworkInfo = FrameworkInfo
+  def buildFrameworkInfo: FrameworkInfo = {
+    FrameworkInfo
       .newBuilder()
       .setUser(
         new SystemProperties()
@@ -74,43 +110,11 @@ object CoreHelloWorldFramework extends StrictLogging {
       .setName("CoreHelloWorldExample")
       .addRoles("test")
       .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
-      .setFailoverTimeout(0d)
+      .setFailoverTimeout(1d)
       .build()
+  }
 
-    val client: MesosClient = Await.result(MesosClient(settings, frameworkInfo).runWith(Sink.head), 10.seconds)
-
-    /**
-      * The signature of the [[schedulerFlow]] might look scary at the first glance (and sometimes even at second) but it is
-      * at the core (!) of any framework. Basically it is a Flow that [[SpecUpdated]] events as input and produces
-      * [[StateEvent]] as an output.
-      *
-      * +--------------------+         +-----------------------+        +-----------------------+
-      * |                    |         |                       |        |                       |
-      * |     SpecUpdated    |         |                       |        |      StateEvent       |
-      * |                    +--------->  Core SchedulerFlow   +-------->                       |
-      * |   new and updated  |         |                       |        | replicated Pod, Agent |
-      * |       PodSpecs     |         |                       |        | and Reservations state|
-      * +--------------------+         +-----------------------+        +-----------------------+
-      *
-      *
-      * In a nutshell: frameworks sends [[PodSpec]] updates down the flow and receives [[StateEvent]]s when things
-      * change. So why is the input parameter of that Flow not simply a [[SpecUpdated]] but a tuple of
-      * [[SpecsSnapshot]] and Source[[SpecUpdated]]? This is because the first message sent to the scheduler
-      * by the framework should be a snapshot of all PodSpecs known to the framework - a [[SpecsSnapshot]]. Internally
-      * this will trigger [task reconciliation](http://mesos.apache.org/documentation/latest/reconciliation/) by the
-      * scheduler.
-      *
-      * The same logic applies for the output parameter of the scheduler Flow - it's a tuple of [[StateSnapshot]] and a
-      * Source of [[StateEvent]], which means that the first state event received by the framework will be a
-      * snapshot of all reconciled tasks states, followed by a individual updates.
-      *
-      * For more about the scheduler flow see [[Scheduler]] class documentation.
-      *
-      */
-    val schedulerFlow
-      : Flow[(SpecsSnapshot, Source[SpecUpdated, Any]), (StateSnapshot, Source[StateEvent, Any]), NotUsed] =
-      Scheduler.fromClient(client)
-
+  def generateSpecSnapshot: SpecsSnapshot = {
     // Lets construct the initial specs snapshot which will contain our hello-world PodSpec. For that we generate
     // - a unique PodId
     // - a RunSpec with minimal resource requirements and hello-world shell command
@@ -126,10 +130,26 @@ object CoreHelloWorldFramework extends StrictLogging {
       runSpec = runSpec
     )
 
-    val specsSnapshot = SpecsSnapshot(
+    SpecsSnapshot(
       podSpecs = Seq(podSpec),
       reservationSpecs = Seq.empty
     )
+  }
+
+  def buildGraph(
+      conf: Config,
+      podRecordRepository: PodRecordRepository,
+      frameworkInfo: FrameworkInfo
+  )(implicit system: ActorSystem, materializer: Materializer): (MesosClient, SchedulerFlow) = {
+    val clientSettings = MesosClientSettings(conf.getString("master-url"))
+    val client: MesosClient = Await.result(MesosClient(clientSettings, frameworkInfo).runWith(Sink.head), 10.seconds)
+    (client, Scheduler.fromClient(client, podRecordRepository))
+  }
+
+  def run(conf: Config)(implicit system: ActorSystem): CoreHelloWorldFramework = {
+    implicit val mat = ActorMaterializer()
+    val (client, schedulerFlow) = buildGraph(conf, InMemoryPodRecordRepository(), buildFrameworkInfo)
+    val specsSnapshot = generateSpecSnapshot
 
     // A trick to make our stream run, even after the initial element (snapshot) is consumed. We use Source.maybe
     // which emits a materialized promise which when completed with a Some, that value will be produced downstream,
@@ -139,7 +159,7 @@ object CoreHelloWorldFramework extends StrictLogging {
     // Note: this is hardly realistic since an orchestrator will need to react to StateEvents by sending SpecUpdates
     // to the scheduler. We're making our lives easier by ignoring this part for now - all we care about is to start
     // a "hello-world" task once.
-    Source.maybe
+    val result: Future[Done] = Source.maybe
       .prepend(Source.single(specsSnapshot))
       .map(snapshot => (snapshot, Source.empty))
       // Here our initial snapshot is going to the scheduler flow
@@ -168,16 +188,7 @@ object CoreHelloWorldFramework extends StrictLogging {
       }
       .toMat(Sink.ignore)(Keep.right)
       .run()
-      .onComplete {
-        case Success(res) =>
-          logger.info(s"Stream completed: $res");
-          system.terminate()
-        case Failure(e) =>
-          logger.error(s"Error in stream: $e");
-          system.terminate()
-      }
 
-    client.frameworkId
-    CoreHelloWorldFramework(frameworkId = client.frameworkId, killSwitch = client.killSwitch)
+    CoreHelloWorldFramework(client.frameworkId, client.killSwitch, result)
   }
 }

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -89,7 +89,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val newPodRecords = customPersistenceStore.readAll().futureValue.values
     newPodRecords should contain theSameElementsAs podRecords
 
-    And(s"no further elements should be emitted")
+    And("no further elements should be emitted")
     assertThrows[AssertionError](sub2.expectNext(5.seconds)) // This is just a best effort check.
     newClient.killSwitch.shutdown()
   }

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -46,7 +46,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val conf = loadConfig
     val frameworkInfo = CoreHelloWorldFramework.buildFrameworkInfo
     val customPersistenceStore = InMemoryPodRecordRepository()
-    customPersistenceStore.readAll().futureValue.size shouldBe 0
+    customPersistenceStore.readAll().runWith(Sink.head).futureValue.size shouldBe 0
     val (mesosClient, scheduler) = CoreHelloWorldFramework.buildGraph(conf, customPersistenceStore, frameworkInfo)
 
     And("an initial pod spec is launched")
@@ -65,7 +65,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     }
 
     And("persistence storage has correct set of records")
-    val podRecords = customPersistenceStore.readAll().futureValue.values
+    val podRecords = customPersistenceStore.readAll().runWith(Sink.head).futureValue.values
     podRecords.size shouldBe 1
     podRecords.head.podId shouldEqual specsSnapshot.podSpecs.head.id
 
@@ -84,7 +84,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     }
 
     And("no new pod records have been created")
-    val newPodRecords = customPersistenceStore.readAll().futureValue.values
+    val newPodRecords = customPersistenceStore.readAll().runWith(Sink.head).futureValue.values
     newPodRecords.size shouldBe 1
     newPodRecords.head shouldEqual podRecords.head
 

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -59,7 +59,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val specsSnapshot = CoreHelloWorldFramework.generateSpecSnapshot
     val (_, sub1) = runGraphAndFeedSnapshot(scheduler, specsSnapshot)
 
-    Then("Receive an empty snapshot is followed by other state events")
+    Then("receive an empty snapshot followed by other state events")
     val e1 = sub1.requestNext()
     e1 shouldBe a[StateSnapshot]
     e1.asInstanceOf[StateSnapshot].podRecords shouldBe empty
@@ -89,8 +89,8 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val newPodRecords = customPersistenceStore.readAll().runWith(Sink.head).futureValue.values
     newPodRecords should contain theSameElementsAs podRecords
 
-    And(s"no new elements should be emitted")
-    assertThrows[AssertionError](sub2.expectNext(5.seconds))
+    And(s"no further elements should be emitted")
+    assertThrows[AssertionError](sub2.expectNext(5.seconds)) // This is just a best effort check.
     newClient.killSwitch.shutdown()
   }
 

--- a/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
+++ b/examples/core-hello-world/src/test/scala/com/mesosphere/usi/examples/CoreHelloWorldFrameworkTest.scala
@@ -52,7 +52,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     val conf = loadConfig
     val frameworkInfo = CoreHelloWorldFramework.buildFrameworkInfo
     val customPersistenceStore = InMemoryPodRecordRepository()
-    customPersistenceStore.readAll().runWith(Sink.head).futureValue.size shouldBe 0
+    customPersistenceStore.readAll().futureValue.size shouldBe 0
     val (mesosClient, scheduler) = CoreHelloWorldFramework.buildGraph(conf, customPersistenceStore, frameworkInfo)
 
     And("an initial pod spec is launched")
@@ -71,7 +71,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     podStatus shouldBe defined
 
     And("persistence storage has correct set of records")
-    val podRecords = customPersistenceStore.readAll().runWith(Sink.head).futureValue.values
+    val podRecords = customPersistenceStore.readAll().futureValue.values
     podRecords.size shouldBe 1
     podRecords.head.podId shouldEqual specsSnapshot.podSpecs.head.id
 
@@ -86,7 +86,7 @@ class CoreHelloWorldFrameworkTest extends AkkaUnitTest with MesosClusterTest wit
     e4.asInstanceOf[StateSnapshot].podRecords should contain theSameElementsAs podRecords
 
     And("no new pod records have been created")
-    val newPodRecords = customPersistenceStore.readAll().runWith(Sink.head).futureValue.values
+    val newPodRecords = customPersistenceStore.readAll().futureValue.values
     newPodRecords should contain theSameElementsAs podRecords
 
     And(s"no further elements should be emitted")

--- a/examples/keep-alive-framework/build.gradle
+++ b/examples/keep-alive-framework/build.gradle
@@ -9,6 +9,8 @@ application {
 dependencies {
     implementation project(':core')
     implementation project(':persistence')
-    testCompile project(':test-utils')
+
+    // Use testCompile when we add implementation project(':persistence-zookeeper')
+    implementation project(':test-utils')
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
 }

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
@@ -6,7 +6,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import com.mesosphere.usi.core.Scheduler
 import com.mesosphere.usi.core.models._
-import com.mesosphere.usi.repository.InMemoryPodRecordRepository
+import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.Protos.{TaskState, TaskStatus}

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -297,7 +297,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
   def apply(conf: MesosClientSettings, frameworkInfo: FrameworkInfo)(
       implicit
       system: ActorSystem,
-      materializer: ActorMaterializer): Source[MesosClient, NotUsed] = {
+      materializer: Materializer): Source[MesosClient, NotUsed] = {
 
     val initialUrl =
       if (conf.master.toLowerCase().startsWith("http://"))

--- a/persistence-zookeeper/build.gradle
+++ b/persistence-zookeeper/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(':core-models')
+    compile project(':persistence')
     implementation project(':metrics')
     implementation project(':test-utils')
 

--- a/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/InMemoryRepositoryTest.scala
+++ b/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/InMemoryRepositoryTest.scala
@@ -1,13 +1,14 @@
 package com.mesosphere.usi.repository
 
 import com.mesosphere.utils.UnitTest
+import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import com.typesafe.scalalogging.StrictLogging
 
 class InMemoryRepositoryTest extends UnitTest with RepositoryBehavior with StrictLogging {
 
   "The in-memory pod record repository" should {
-    behave like podRecordStore(() => InMemoryPodRecordRepository.apply())
-    behave like podRecordReadAll(() => InMemoryPodRecordRepository.apply())
-    behave like podRecordDelete(() => InMemoryPodRecordRepository.apply())
+    behave like podRecordStore(() => InMemoryPodRecordRepository())
+    behave like podRecordReadAll(() => InMemoryPodRecordRepository())
+    behave like podRecordDelete(() => InMemoryPodRecordRepository())
   }
 }

--- a/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/InMemoryRepositoryTest.scala
+++ b/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/InMemoryRepositoryTest.scala
@@ -1,0 +1,13 @@
+package com.mesosphere.usi.repository
+
+import com.mesosphere.utils.UnitTest
+import com.typesafe.scalalogging.StrictLogging
+
+class InMemoryRepositoryTest extends UnitTest with RepositoryBehavior with StrictLogging {
+
+  "The in-memory pod record repository" should {
+    behave like podRecordStore(() => InMemoryPodRecordRepository.apply())
+    behave like podRecordReadAll(() => InMemoryPodRecordRepository.apply())
+    behave like podRecordDelete(() => InMemoryPodRecordRepository.apply())
+  }
+}

--- a/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
+++ b/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
@@ -1,0 +1,121 @@
+package com.mesosphere.usi.repository
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import com.mesosphere.usi.core.models.{AgentId, PodId, PodRecord}
+import com.mesosphere.utils.UnitTest
+
+/**
+  * The [[RepositoryBehavior]] defines the behavior each implementation of [[PodRecordRepository]] and [[ReservationRecordRepository]]
+  * should follow. See the unit tests of the Zookeeper persistence package for an example.
+  */
+trait RepositoryBehavior { this: UnitTest =>
+
+  val podCount = new AtomicInteger()
+
+  /**
+    * This defines the expected behavior of creating/updating pods in a repository.
+    *
+    * @param newRepo A repo factory function. Each test case creates its own repository.
+    */
+  def podRecordStore(newRepo: () => PodRecordRepository): Unit = {
+
+    "create a record" in {
+      val f = Fixture()
+      val repo = newRepo()
+      repo.store(f.record).futureValue should be(f.record.podId)
+    }
+
+    "update a record" in {
+      val f = Fixture()
+      val podId = PodId("second_pod")
+      val record = f.record.copy(podId = podId)
+
+      Given("a record already exists")
+      val repo = newRepo()
+      repo.store(record).futureValue should be(podId)
+
+      Then("the record is updated")
+      repo.store(record).futureValue should be(podId)
+    }
+  }
+
+  /**
+    * This defines the expected behavior of reading pods from a repository.
+    *
+    * @param newRepo A repo factory function. Each test case creates its own repository.
+    */
+  def podRecordReadAll(newRepo: () => PodRecordRepository): Unit = {
+
+    "read all records" in {
+      val f = Fixture()
+
+      Given(s"a known record id ${f.podId}")
+      val repo = newRepo()
+      repo.store(f.record).futureValue
+
+      When("all records are read")
+      val maybeRecord = repo.readAll().futureValue
+
+      Then("the stored record is returned")
+      maybeRecord.head should be(f.record.podId -> f.record)
+    }
+
+    "read all records should return all the records" in {
+      val fixtures = Seq(Fixture(), Fixture(), Fixture(), Fixture(), Fixture())
+
+      Given(s"few known record ids ${fixtures.map(_.podId)}")
+      val repo = newRepo()
+      fixtures.map(_.record).map(repo.store).map(_.futureValue)
+
+      When("all records are read")
+      val records = repo.readAll().futureValue
+
+      Then("all the stored records are returned")
+      records.values should contain theSameElementsAs fixtures.map(_.record)
+    }
+  }
+
+  /**
+    * This defines the expected behavior of deleting pods from a repository.
+    *
+    * @param newRepo A repo factory function. Each test case creates its own repository.
+    */
+  def podRecordDelete(newRepo: () => PodRecordRepository): Unit = {
+
+    "delete a record" in {
+      val f = Fixture()
+
+      Given(s"a known record id ${f.podId}")
+      val repo = newRepo()
+      repo.store(f.record).futureValue
+
+      When("the record is deleted")
+      repo.delete(f.podId).futureValue
+
+      Then("the record should not exist")
+      repo.readAll().futureValue should not contain f.podId -> f.record
+    }
+
+    "delete an unknown record" in {
+      Given(s"an unknown record id")
+      val repo = newRepo()
+      val unknownPodId = PodId("unknown")
+
+      When("the unknown record is deleted")
+      val result = repo.delete(unknownPodId)
+
+      Then("no error is returned")
+      result.futureValue
+
+      And("the record should not exist")
+      repo.readAll().futureValue shouldBe empty
+    }
+  }
+
+  case class Fixture() {
+    val podId = PodId(s"pod_${podCount.getAndIncrement()}")
+    val agentId = AgentId("my_agent")
+    val record = PodRecord(podId, Instant.now(), agentId)
+  }
+}

--- a/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
+++ b/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
@@ -19,6 +19,7 @@ import com.mesosphere.utils.UnitTest
   * should follow. See the unit tests of the Zookeeper persistence package for an example.
   */
 trait RepositoryBehavior extends AkkaUnitTestLike { this: UnitTest =>
+  // This trait should ideally be located in test-utils module but moving this to test-utils will result in a cyclic dependency.
 
   val podCount = new AtomicInteger()
 

--- a/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
+++ b/persistence-zookeeper/src/test/scala/com/mesosphere/usi/repository/RepositoryBehavior.scala
@@ -97,7 +97,7 @@ trait RepositoryBehavior { this: UnitTest =>
       repo.readAll().futureValue should not contain f.podId -> f.record
     }
 
-    "delete an unknown record" in {
+    "delete is idempotent" in {
       Given(s"an unknown record id")
       val repo = newRepo()
       val unknownPodId = PodId("unknown")

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
@@ -1,0 +1,30 @@
+package com.mesosphere.usi.repository
+
+import com.mesosphere.usi.core.models.{PodId, PodRecord}
+import com.typesafe.scalalogging.StrictLogging
+import scala.collection.mutable
+import scala.concurrent.Future
+
+/**
+  * A simple in memory implementation of the [[PodRecordRepository]]. It should not be used in production but merely
+  * defines a common behavior to all CRUD repositories used by USI.
+  */
+case class InMemoryPodRecordRepository() extends PodRecordRepository with StrictLogging {
+  val data = mutable.Map.empty[PodId, PodRecord]
+
+  override def store(record: PodRecord): Future[PodId] = synchronized {
+    logger.info(s"Create record ${record.podId}")
+    data += record.podId -> record
+    Future.successful(record.podId)
+  }
+
+  override def delete(podId: PodId): Future[Unit] = synchronized {
+    data -= podId
+    Future.unit
+  }
+
+  override def readAll(): Future[Map[PodId, PodRecord]] = {
+    Future.successful(data.toMap)
+  }
+
+}

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.usi.repository
 
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
 import com.mesosphere.usi.core.models.{PodId, PodRecord}
 import com.typesafe.scalalogging.StrictLogging
 import scala.collection.mutable
@@ -18,10 +20,16 @@ case class InMemoryPodRecordRepository() extends PodRecordRepository with Strict
     Future.successful(record.podId)
   }
 
+  override def storeFlow: Flow[PodRecord, PodId, NotUsed] =
+    Flow[PodRecord].mapAsync(1)(store)
+
   override def delete(podId: PodId): Future[Unit] = synchronized {
     data -= podId
     Future.unit
   }
+
+  override def deleteFlow: Flow[PodId, Unit, NotUsed] =
+    Flow[PodId].mapAsync(1)(delete)
 
   override def readAll(): Future[Map[PodId, PodRecord]] = {
     Future.successful(data.toMap)

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
@@ -1,8 +1,6 @@
 package com.mesosphere.usi.repository
 
-import akka.NotUsed
-import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.Source
+import akka.Done
 import com.mesosphere.usi.core.models.{PodId, PodRecord}
 import com.typesafe.scalalogging.StrictLogging
 import scala.collection.mutable
@@ -15,26 +13,20 @@ import scala.concurrent.Future
 case class InMemoryPodRecordRepository() extends PodRecordRepository with StrictLogging {
   val data = mutable.Map.empty[PodId, PodRecord]
 
-  override def storeFlow: Flow[PodRecord, PodId, NotUsed] =
-    Flow[PodRecord].map { record =>
-      synchronized {
-        logger.info(s"Create record ${record.podId}")
-        data += record.podId -> record
-        record.podId
-      }
-    }
+  override def store(record: PodRecord): Future[Done] = synchronized {
+    logger.info(s"Create record ${record.podId}")
+    data += record.podId -> record
+    Future.successful(Done)
+  }
 
-  override def deleteFlow: Flow[PodId, Unit, NotUsed] =
-    Flow[PodId].map { podId =>
-      synchronized {
-        logger.info(s"Delete record $podId")
-        data -= podId
-        Future.unit
-      }
-    }
+  override def delete(podId: PodId): Future[Done] = synchronized {
+    logger.info(s"Delete record $podId")
+    data -= podId
+    Future.successful(Done)
+  }
 
-  override def readAll(): Source[Map[PodId, PodRecord], NotUsed] = {
-    Source.single(data.toMap)
+  override def readAll(): Future[Map[PodId, PodRecord]] = {
+    Future.successful(data.toMap)
   }
 
 }

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
@@ -2,6 +2,7 @@ package com.mesosphere.usi.repository
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
 import com.mesosphere.usi.core.models.{PodId, PodRecord}
 import com.typesafe.scalalogging.StrictLogging
 import scala.collection.mutable
@@ -14,26 +15,26 @@ import scala.concurrent.Future
 case class InMemoryPodRecordRepository() extends PodRecordRepository with StrictLogging {
   val data = mutable.Map.empty[PodId, PodRecord]
 
-  override def store(record: PodRecord): Future[PodId] = synchronized {
-    logger.info(s"Create record ${record.podId}")
-    data += record.podId -> record
-    Future.successful(record.podId)
-  }
-
   override def storeFlow: Flow[PodRecord, PodId, NotUsed] =
-    Flow[PodRecord].mapAsync(1)(store)
-
-  override def delete(podId: PodId): Future[Unit] = synchronized {
-    logger.info(s"Delete record $podId")
-    data -= podId
-    Future.unit
-  }
+    Flow[PodRecord].map { record =>
+      synchronized {
+        logger.info(s"Create record ${record.podId}")
+        data += record.podId -> record
+        record.podId
+      }
+    }
 
   override def deleteFlow: Flow[PodId, Unit, NotUsed] =
-    Flow[PodId].mapAsync(1)(delete)
+    Flow[PodId].map { podId =>
+      synchronized {
+        logger.info(s"Delete record $podId")
+        data -= podId
+        Future.unit
+      }
+    }
 
-  override def readAll(): Future[Map[PodId, PodRecord]] = {
-    Future.successful(data.toMap)
+  override def readAll(): Source[Map[PodId, PodRecord], NotUsed] = {
+    Source.single(data.toMap)
   }
 
 }

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/InMemoryPodRecordRepository.scala
@@ -24,6 +24,7 @@ case class InMemoryPodRecordRepository() extends PodRecordRepository with Strict
     Flow[PodRecord].mapAsync(1)(store)
 
   override def delete(podId: PodId): Future[Unit] = synchronized {
+    logger.info(s"Delete record $podId")
     data -= podId
     Future.unit
   }

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
@@ -9,8 +9,7 @@ trait RecordRepository {
   type RecordId
 
   /**
-    * Stores the provided record in the repository if it doesn't exist.
-    * If the record is already there, resulting future will be failed with a [[RecordAlreadyExistsException]].
+    * Create/update the provided record in the repository.
     * @param record
     * @return id of the provided record
     */
@@ -23,14 +22,9 @@ trait RecordRepository {
   def readAll(): Future[Map[RecordId, Record]]
 
   /**
-    * Deletes the record if it exists. If the record is missing,
-    * * the future will be failed with an [[RecordNotFoundException]].
-    *
+    * Deletes the record if it exists. If the record is missing, this is a no-op.
     * @param recordId
     * @return Unit either if the node delete was successful OR if the node did not exist.
     */
   def delete(recordId: RecordId): Future[Unit]
 }
-
-case class RecordAlreadyExistsException(id: String) extends RuntimeException(s"record with id $id already exists.")
-case class RecordNotFoundException(id: String) extends RuntimeException(s"record with id $id doesn't exist.")

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.usi.repository
 
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
 import scala.concurrent.Future
 
 trait RecordRepository {
@@ -14,6 +16,7 @@ trait RecordRepository {
     * @return id of the provided record
     */
   def store(record: Record): Future[RecordId]
+  def storeFlow: Flow[Record, RecordId, NotUsed]
 
   /**
     * Retrieves all the existing records (if any).
@@ -27,4 +30,5 @@ trait RecordRepository {
     * @return Unit either if the node delete was successful OR if the node did not exist.
     */
   def delete(recordId: RecordId): Future[Unit]
+  def deleteFlow: Flow[RecordId, Unit, NotUsed]
 }

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
@@ -2,7 +2,7 @@ package com.mesosphere.usi.repository
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import scala.concurrent.Future
+import akka.stream.scaladsl.Source
 
 trait RecordRepository {
 
@@ -11,24 +11,19 @@ trait RecordRepository {
   type RecordId
 
   /**
-    * Create/update the provided record in the repository.
-    * @param record
-    * @return id of the provided record
+    * Flow that deletes the [[Record]] for given [[RecordId]] if it exists. If the record is missing, this is a no-op.
     */
-  def store(record: Record): Future[RecordId]
+  def deleteFlow: Flow[RecordId, Unit, NotUsed]
+
+  /**
+    * Flow that consumes a [[Record]] and emits a corresponding [[RecordId]] after a successful create/update.
+    */
   def storeFlow: Flow[Record, RecordId, NotUsed]
 
   /**
-    * Retrieves all the existing records (if any).
-    * @return Map containing all the current pod records. Can be empty if there are no pod records.
+    * Source that retrieves all the existing records (if any) at the time of materialization. Creates a map containing
+    * all the current records on every materialization. Can be an empty map if there are no records.
+    * Source completes after emitting the current snapshot.
     */
-  def readAll(): Future[Map[RecordId, Record]]
-
-  /**
-    * Deletes the record if it exists. If the record is missing, this is a no-op.
-    * @param recordId
-    * @return Unit either if the node delete was successful OR if the node did not exist.
-    */
-  def delete(recordId: RecordId): Future[Unit]
-  def deleteFlow: Flow[RecordId, Unit, NotUsed]
+  def readAll(): Source[Map[RecordId, Record], NotUsed]
 }

--- a/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
+++ b/persistence/src/main/scala/com/mesosphere/usi/repository/RecordRepository.scala
@@ -14,33 +14,23 @@ trait RecordRepository {
     * @param record
     * @return id of the provided record
     */
-  def create(record: Record): Future[RecordId]
+  def store(record: Record): Future[RecordId]
 
   /**
-    * Retrieves the record if it exists.
-    * @param recordId
-    * @return Option(record) if it exists, None otherwise
+    * Retrieves all the existing records (if any).
+    * @return Map containing all the current pod records. Can be empty if there are no pod records.
     */
-  def read(recordId: RecordId): Future[Option[Record]]
-
-  /**
-    * Updates the record if it exists. If the record is missing,
-    * the future will be failed with an [[RecordNotFoundException]].
-    *
-    * @param record
-    * @return id of the updated record
-    */
-  def update(record: Record): Future[RecordId]
+  def readAll(): Future[Map[RecordId, Record]]
 
   /**
     * Deletes the record if it exists. If the record is missing,
     * * the future will be failed with an [[RecordNotFoundException]].
     *
-    * @param record
-    * @return id of the deleted record
+    * @param recordId
+    * @return Unit either if the node delete was successful OR if the node did not exist.
     */
-  def delete(record: Record): Future[RecordId]
+  def delete(recordId: RecordId): Future[Unit]
 }
 
-class RecordAlreadyExistsException(id: String) extends RuntimeException(s"record with id $id already exists.")
-class RecordNotFoundException(id: String) extends RuntimeException(s"record with id $id doesn't exist.")
+case class RecordAlreadyExistsException(id: String) extends RuntimeException(s"record with id $id already exists.")
+case class RecordNotFoundException(id: String) extends RuntimeException(s"record with id $id doesn't exist.")

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':metrics')
+    implementation project(':persistence')
 
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'de.heikoseeberger', name: "akka-http-play-json_$scalaVersion", version: '1.18.1'

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -6,11 +6,11 @@ dependencies {
     compile group: 'org.scala-lang.modules', name: "scala-async_$scalaVersion", version: '0.9.7'
     compile "org.scalatest:scalatest_$scalaVersion:3.0.5"
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.3.1'
-    
+    compile "com.typesafe.akka:akka-stream-testkit_$scalaVersion:2.5.22"
+
     // Provides import org.junit.runner.RunWith. We probably want to move to a different test platform for Scalatest or
     // use the Scalatest Runner.
     compile 'junit:junit:4.12'
-    
-    testCompile "com.typesafe.akka:akka-testkit_$scalaVersion:2.5.14"
-    testCompile "org.scalatest:scalatest_$scalaVersion:3.0.4"
+
+    testCompile "com.typesafe.akka:akka-testkit_$scalaVersion:2.5.22"
 }

--- a/test-utils/src/main/scala/com/mesosphere/utils/persistence/InMemoryPodRecordRepository.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/persistence/InMemoryPodRecordRepository.scala
@@ -1,7 +1,9 @@
-package com.mesosphere.usi.repository
+package com.mesosphere.utils.persistence
 
 import akka.Done
-import com.mesosphere.usi.core.models.{PodId, PodRecord}
+import com.mesosphere.usi.core.models.PodId
+import com.mesosphere.usi.core.models.PodRecord
+import com.mesosphere.usi.repository.PodRecordRepository
 import com.typesafe.scalalogging.StrictLogging
 import scala.collection.mutable
 import scala.concurrent.Future


### PR DESCRIPTION
Add a persistence storage interface and create a flow from it to use in the Scheduler graph. This PR adds the following changes

- Create a generic RecordRepository trait. Currently, only `PodRecordRepository` is implemented.
- Handle the initial snapshot loading from the `PodRecordRepository`.
- Create a scheduler graph component that uses the `PodRecordRepository` to persist the `SchedulerEvents`. This component itself performs materialization for every `SchedulerEvents` element.

#### Testing
- Add a `RepositoryBehavior` that can be used to verify all the implementors of `RecordRepository`. Currently used only for InMemory storage but can/will be extended to other implementations (such as zk).
- Add the akka-stream-testkit library dependency to `test-utils` module so that it can be used in other modules.
- Add a unit test for the persistence flow component.
- Add an integration test to verify the atmost once launch guarantee.

@jeschkies made the initial PR #51 that laid some groundwork for this.

JIRA : DCOS-49274