### PR TITLE
Remove the size limit on mesos http stream

### DIFF
--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -319,7 +319,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
       case (httpResponse, connectionInfo) =>
         val sharedKillSwitch =
           KillSwitches.shared(s"MesosClient-${conf.master}")
-        httpResponse.entity.dataBytes
+        httpResponse.entity.withoutSizeLimit.dataBytes
           .via(eventReader)
           .via(sharedKillSwitch.flow)
           .prefixAndTail(1)


### PR DESCRIPTION
By default, Akka HTTP restricts the size of any HTTP entity to 8Mb. This usually helps to prevent OOM, but it's not very applicable when we want to consume an endless stream from mesos. This fix removes the size limit on that mesos HTTP entity.