### PR TITLE
Notify downstream termination for scheduler flow

### DIFF
--- a/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/Scheduler.scala
@@ -84,7 +84,7 @@ object Scheduler {
     fromFlow(
       client.calls,
       podRecordRepository,
-      Flow.fromSinkAndSource(client.mesosSink, client.mesosSource),
+      Flow.fromSinkAndSourceCoupled(client.mesosSink, client.mesosSource),
       schedulerSettings)
   }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/japi/Scheduler.scala
@@ -32,7 +32,7 @@ object Scheduler {
       client: MesosClient,
       podRecordRepository: PodRecordRepository,
       schedulerSettings: SchedulerSettings): CompletableFuture[FlowResult] = {
-    val flow = Flow.fromSinkAndSource(client.mesosSink, client.mesosSource)
+    val flow = Flow.fromSinkAndSourceCoupled(client.mesosSink, client.mesosSource)
     fromFlow(client.calls, podRecordRepository, flow, schedulerSettings)
   }
 


### PR DESCRIPTION
We were using fromSinkAndSource, which does not notify the flow downstream
(source) if the upstream (sink) receives a failure. Switching to
fromSinkAndSourceCoupled resolves this.