### PR TITLE
Run Keep Alive Framework on strict.

### DIFF
--- a/ci.gradle
+++ b/ci.gradle
@@ -72,7 +72,8 @@ task ci {
     subprojects*.test.each { it.ignoreFailures = true }
 
     if (TravisEnvironment.isMasterBuild()) {
-        dependsOn githubReport, gitPublishPush
+        dependsOn githubReport, gitPublishPush 
+        dependsOn ':keep-alive-framework:uploadTarball'
     } else if (TravisEnvironment.isSecureBuild())  {
         dependsOn githubReport
     }

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/FCFSOfferMatcher.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/FCFSOfferMatcher.scala
@@ -37,7 +37,6 @@ class FCFSOfferMatcher extends OfferMatcher {
   }
 
   @tailrec private def matchPodSpecsTaskRecords(
-      offer: Mesos.Offer,
       remainingResources: Map[ResourceType, Seq[Mesos.Resource]],
       result: Map[RunningPodSpec, List[Mesos.Resource]],
       pendingLaunchPodSpecs: List[RunningPodSpec]): Map[RunningPodSpec, List[Mesos.Resource]] = {
@@ -49,9 +48,9 @@ class FCFSOfferMatcher extends OfferMatcher {
       case podSpec :: rest =>
         maybeMatchPodSpec(remainingResources, Nil, podSpec.runSpec.resourceRequirements.toList) match {
           case Some((matchedResources, newRemainingResources)) =>
-            matchPodSpecsTaskRecords(offer, newRemainingResources, result.updated(podSpec, matchedResources), rest)
+            matchPodSpecsTaskRecords(newRemainingResources, result.updated(podSpec, matchedResources), rest)
           case None =>
-            matchPodSpecsTaskRecords(offer, remainingResources, result, rest)
+            matchPodSpecsTaskRecords(remainingResources, result, rest)
         }
     }
   }
@@ -60,6 +59,6 @@ class FCFSOfferMatcher extends OfferMatcher {
       offer: Mesos.Offer,
       podSpecs: Iterable[RunningPodSpec]): Map[RunningPodSpec, List[Mesos.Resource]] = {
     val groupedResources = offer.getResourcesList.asScala.groupBy(r => ResourceType.fromName(r.getName))
-    matchPodSpecsTaskRecords(offer, groupedResources, Map.empty, podSpecs.toList)
+    matchPodSpecsTaskRecords(groupedResources, Map.empty, podSpecs.toList)
   }
 }

--- a/examples/keep-alive-framework/README.md
+++ b/examples/keep-alive-framework/README.md
@@ -16,12 +16,14 @@ Run the keep-alive example framework that:
    ```
    dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi
    ```
-4. Grant `strict-usi` access:
+4. Store private key as secret:
    ```
-   curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
-       "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"
+   dcos security secrets create -f ./usi.private.pem usi/private_key
    ```
-5. Great a secret from `usi.private.pem`: `dcos ???`
+5. Grant `strict-usi` access:
+   ```
+   dcos security org users grant strict-usi dcos:mesos:master:task:user:nobody create
+   ```
 6. Deploy the framework:
    ```
    dcos marathon app add keep-alive-framework-app.json

--- a/examples/keep-alive-framework/README.md
+++ b/examples/keep-alive-framework/README.md
@@ -9,12 +9,20 @@ Run the keep-alive example framework that:
 
 1. Launch strict cluster and setup the DC/OS CLI.
 2. Create key pair:
-   `dcos security org service-accounts keypair usi.private.pem usi.pub.pem`
+   ```
+   dcos security org service-accounts keypair usi.private.pem usi.pub.pem
+   ```
 3. Create user `strict-usi`:
-   dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi`
+   ```
+   dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi
+   ```
 4. Grant `strict-usi` access:
-   ```curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
-      "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"
+   ```
+   curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+       "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"
    ```
 5. Great a secret from `usi.private.pem`: `dcos ???`
-6. Deploy the framework: `dcos marathon app add keep-alive-framework-app.json`
+6. Deploy the framework:
+   ```
+   dcos marathon app add keep-alive-framework-app.json
+   ```

--- a/examples/keep-alive-framework/README.md
+++ b/examples/keep-alive-framework/README.md
@@ -4,3 +4,15 @@ Run the keep-alive example framework that:
 - uses simplified Scheduler interface
 - starts configurable amount of `echo "Hello, world" && sleep 20` tasks (default 100)
 - keeps restarting the task if it finishes
+
+# Deployment on DC/OS Enterprise
+
+1. Launch strict cluster and setup the DC/OS CLI.
+2. Create key pair:
+   `dcos security org service-accounts keypair usi.private.pem usi.pub.pem`
+3. Create user `strict-usi`:
+   dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi`
+4. Grant `strict-usi` access:
+   `curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"`
+5. Great a secret from `usi.private.pem`: `dcos ???`
+6. Deploy the framework: `dcos marathon app add keep-alive-framework-app.json`

--- a/examples/keep-alive-framework/README.md
+++ b/examples/keep-alive-framework/README.md
@@ -13,6 +13,8 @@ Run the keep-alive example framework that:
 3. Create user `strict-usi`:
    dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi`
 4. Grant `strict-usi` access:
-   `curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"`
+   ```curl -L -X PUT -k -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+      "$(dcos config show core.dcos_url)/acs/api/v1/acls/dcos:superuser/users/strict-usi/full"
+   ```
 5. Great a secret from `usi.private.pem`: `dcos ???`
 6. Deploy the framework: `dcos marathon app add keep-alive-framework-app.json`

--- a/examples/keep-alive-framework/build.gradle
+++ b/examples/keep-alive-framework/build.gradle
@@ -1,3 +1,5 @@
+import mesosphere.gradle.aws.S3Upload
+
 plugins {
     id 'application'
 }
@@ -13,4 +15,15 @@ dependencies {
     // Use testCompile when we add implementation project(':persistence-zookeeper')
     implementation project(':test-utils')
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
+}
+
+task uploadTarball(type: S3Upload) {
+    description = "Upload the framework tarball to S3."
+    group = "CI"
+    dependsOn distTar
+
+    region = "us-west-2"
+    bucket = "usi-builds"
+    prefix = "mesosphere/usi/artifacts"
+    source = files(distTar.archiveFile).asFileTree
 }

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -4,7 +4,7 @@
   "id": "/usi/keep-alive-framework",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
-  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://master.mesos https://leader.mesos:5050 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/amazon-corretto*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://master.mesos https://leader.mesos:5050 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
   "container": {
     "type": "MESOS",
     "volumes": [
@@ -24,7 +24,7 @@
       "cache": false
     },
     {
-      "uri": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
+      "uri": "https://d3pxv6yz143wms.cloudfront.net/8.222.10.1/amazon-corretto-8.222.10.1-linux-x64.tar.gz",
       "extract": true,
       "executable": false,
       "cache": true

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -18,7 +18,7 @@
   "disk": 0,
   "fetch": [
     {
-      "uri": "https://s3-us-west-2.amazonaws.com/usi-builds/mesosphere/usi/ad/artifacts/keep-alive-framework-0.1.tar",
+      "uri": "https://s3-us-west-2.amazonaws.com/usi-builds/mesosphere/usi/artifacts/keep-alive-framework-0.1.tar",
       "extract": true,
       "executable": false,
       "cache": false

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -4,7 +4,7 @@
   "id": "/usi/keep-alive-framework",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
-  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 https://34.220.172.49/master $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://master.mesos https://leader.mesos:5050 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
   "container": {
     "type": "MESOS",
     "volumes": [

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -1,0 +1,60 @@
+{
+  "env": {
+  },
+  "id": "/usi/keep-alive-framework",
+  "backoffFactor": 1.15,
+  "backoffSeconds": 1,
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; export DCOS_CERT=\"$MESOS_SANDBOX/.ssl/ca-bundle.crt\" && ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 $MESOS_SANDBOX/private_key.pem",
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "private_key.pem",
+        "secret": "private_key"
+      }
+    ]
+  },
+  "cpus": 0.5,
+  "disk": 0,
+  "fetch": [
+    {
+      "uri": "https://s3-us-west-2.amazonaws.com/usi-builds/mesosphere/usi/ad/artifacts/keep-alive-framework-0.1.tar",
+      "extract": true,
+      "executable": false,
+      "cache": false
+    },
+    {
+      "uri": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
+      "extract": true,
+      "executable": false,
+      "cache": true
+    }
+  ],
+  "instances": 1,
+  "maxLaunchDelaySeconds": 3600,
+  "mem": 1024,
+  "gpus": 0,
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+  "portDefinitions": [],
+  "requirePorts": false,
+  "upgradeStrategy": {
+    "maximumOverCapacity": 1,
+    "minimumHealthCapacity": 1
+  },
+  "killSelection": "YOUNGEST_FIRST",
+  "unreachableStrategy": {
+    "inactiveAfterSeconds": 0,
+    "expungeAfterSeconds": 0
+  },
+  "healthChecks": [],
+  "constraints": [],
+  "secrets": {
+    "private_key": {
+      "source": "usi_private"
+    }
+  }
+}

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -4,7 +4,7 @@
   "id": "/usi/keep-alive-framework",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
-  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 https://34.220.172.49/master $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
   "container": {
     "type": "MESOS",
     "volumes": [

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -4,7 +4,7 @@
   "id": "/usi/keep-alive-framework",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
-  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; export DCOS_CERT=\"$MESOS_SANDBOX/.ssl/ca-bundle.crt\" && ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 $MESOS_SANDBOX/private_key.pem",
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://34.220.172.49 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
   "container": {
     "type": "MESOS",
     "volumes": [

--- a/examples/keep-alive-framework/src/main/resources/application.conf
+++ b/examples/keep-alive-framework/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 # This is still the default configuration but it's good to see what can be changed
 mesos-client {
 
-  master-url: "127.0.0.1:5050"
+  master-url: "http://127.0.0.1:5050"
 
   max-redirects: 3
 
@@ -26,6 +26,15 @@ akka {
     # The time after which an idle connection will be automatically closed.
     # Set to `infinite` to completely disable idle timeouts.
     idle-timeout = infinite
+  }
+
+  ssl-config {
+    trustManager = {
+      stores = [
+        { type: "PEM", path: ${?DCOS_CERT}  }     # Added trust store
+        { path: ${java.home}/lib/security/cacerts } # Fallback to default JSSE trust store
+      ]
+    }
   }
 }
 

--- a/examples/keep-alive-framework/src/main/resources/application.conf
+++ b/examples/keep-alive-framework/src/main/resources/application.conf
@@ -27,14 +27,6 @@ akka {
     # Set to `infinite` to completely disable idle timeouts.
     idle-timeout = infinite
   }
-
-  ssl-config {
-    trustManager = {
-      stores = [
-        { path: ${java.home}/lib/security/cacerts } # Fallback to default JSSE trust store
-      ]
-    }
-  }
 }
 
 keep-alive-framework {

--- a/examples/keep-alive-framework/src/main/resources/application.conf
+++ b/examples/keep-alive-framework/src/main/resources/application.conf
@@ -39,5 +39,5 @@ akka {
 }
 
 keep-alive-framework {
-  tasks-started = 100
+  tasks-started = 10
 }

--- a/examples/keep-alive-framework/src/main/resources/application.conf
+++ b/examples/keep-alive-framework/src/main/resources/application.conf
@@ -31,7 +31,6 @@ akka {
   ssl-config {
     trustManager = {
       stores = [
-        { type: "PEM", path: ${?DCOS_CERT}  }     # Added trust store
         { path: ${java.home}/lib/security/cacerts } # Fallback to default JSSE trust store
       ]
     }

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
@@ -110,6 +110,13 @@ class KeepAliveFramework(settings: KeepAliveFrameWorkSettings, authorization: Op
 
 object KeepAliveFramework {
 
+  /**
+    * Set ups the same way as [[MesosClientExampleFramework.main]] and run with
+    * {{{
+    *   DCOS_CERT="$(pwd)/dcos-ca.crt" ./gradlew :keep-alive-framework:run --stacktrace \
+    *     --args "$(dcos config show core.dcos_url) $(dcos config show core.dcos_url)/mesos $(pwd)/usi.private.pem strict-usi"
+    * }}}
+    */
   def main(args: Array[String]): Unit = {
 
     require(
@@ -122,7 +129,7 @@ object KeepAliveFramework {
 
     val dcosRoot = new URL(args(0))
     val mesosUrl = new URL(args(1))
-    val provider = if (args.length == 3) {
+    val provider = if (args.length == 4) {
       val privateKey = scala.io.Source.fromFile(args(2)).mkString
       Some(DcosServiceAccountProvider(args(3), privateKey, dcosRoot))
     } else {

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -21,7 +21,7 @@ class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: 
     .newBuilder()
     .setUser("root")
     .setName("KeepAliveFramework")
-    .addRoles("slave_public")
+    .addRoles("test")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .setFailoverTimeout(0d)
     .build()

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -3,9 +3,8 @@ package com.mesosphere.usi.helloworld
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
-import com.mesosphere.mesos.client.MesosClient
+import com.mesosphere.mesos.client.{CredentialsProvider, MesosClient}
 import com.mesosphere.mesos.conf.MesosClientSettings
-import com.typesafe.config.Config
 import org.apache.mesos.v1.Protos.FrameworkInfo
 
 import scala.concurrent.duration._
@@ -13,22 +12,24 @@ import scala.concurrent.Await
 import scala.sys.SystemProperties
 
 /**
-  * Helper that builds a mesos client that can be used by USI
+  * Helper that builds a Mesos client that can be used by USI
   */
-class KeepAliveMesosClientFactory(conf: Config)(implicit system: ActorSystem, mat: ActorMaterializer) {
+class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: Option[CredentialsProvider])(
+    implicit system: ActorSystem,
+    mat: ActorMaterializer) {
 
-  val settings = MesosClientSettings.fromConfig(conf)
   val frameworkInfo = FrameworkInfo
     .newBuilder()
     .setUser(
       new SystemProperties()
         .get("user.name")
-        .getOrElse(throw new IllegalArgumentException("A local user is needed to launch Mesos tasks")))
+        .getOrElse("root"))
     .setName("KeepAliveFramework")
-    .addRoles("test")
+    .addRoles("*")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .setFailoverTimeout(0d)
     .build()
 
-  val client: MesosClient = Await.result(MesosClient(settings, frameworkInfo).runWith(Sink.head), 10.seconds)
+  val client: MesosClient =
+    Await.result(MesosClient(settings, frameworkInfo, authorization).runWith(Sink.head), 10.seconds)
 }

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -9,7 +9,6 @@ import org.apache.mesos.v1.Protos.FrameworkInfo
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
-import scala.sys.SystemProperties
 
 /**
   * Helper that builds a Mesos client that can be used by USI
@@ -20,10 +19,7 @@ class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: 
 
   val frameworkInfo = FrameworkInfo
     .newBuilder()
-    .setUser(
-      new SystemProperties()
-        .get("user.name")
-        .getOrElse("root"))
+    .setUser("root")
     .setName("KeepAliveFramework")
     .addRoles("slave_public")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -19,7 +19,7 @@ class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: 
 
   val frameworkInfo = FrameworkInfo
     .newBuilder()
-    .setUser("root")
+    .setUser("nobody")
     .setName("KeepAliveFramework")
     .addRoles("test")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -25,7 +25,7 @@ class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: 
         .get("user.name")
         .getOrElse("root"))
     .setName("KeepAliveFramework")
-    .addRoles("*")
+    .addRoles("slave_public")
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .setFailoverTimeout(0d)
     .build()

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAlivePodSpecHelper.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAlivePodSpecHelper.scala
@@ -13,7 +13,7 @@ object KeepAlivePodSpecHelper {
   val runSpec: RunTemplate = RunTemplate(
     resourceRequirements = List(ScalarRequirement(ResourceType.CPUS, 0.001), ScalarRequirement(ResourceType.MEM, 32)),
     shellCommand = """echo "Hello, world" && sleep 30""",
-    role = "test"
+    role = "slave_public"
   )
 
   def generatePodSpec(): RunningPodSpec = {

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAlivePodSpecHelper.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAlivePodSpecHelper.scala
@@ -13,7 +13,7 @@ object KeepAlivePodSpecHelper {
   val runSpec: RunTemplate = RunTemplate(
     resourceRequirements = List(ScalarRequirement(ResourceType.CPUS, 0.001), ScalarRequirement(ResourceType.MEM, 32)),
     shellCommand = """echo "Hello, world" && sleep 30""",
-    role = "slave_public"
+    role = "test"
   )
 
   def generatePodSpec(): RunningPodSpec = {

--- a/examples/mesos-client-example/src/main/resources/application.conf
+++ b/examples/mesos-client-example/src/main/resources/application.conf
@@ -27,13 +27,4 @@ akka {
     # Set to `infinite` to completely disable idle timeouts.
     idle-timeout = infinite
   }
-
-  ssl-config {
-    trustManager = {
-      stores = [
-        { type: "PEM", path: ${?DCOS_CERT}  }     # Added trust store
-        { path: ${java.home}/lib/security/cacerts } # Fallback to default JSSE trust store
-      ]
-    }
-  }
 }

--- a/examples/mesos-client-example/src/main/scala/com/mesosphere/mesos/examples/MesosClientExampleFramework.scala
+++ b/examples/mesos-client-example/src/main/scala/com/mesosphere/mesos/examples/MesosClientExampleFramework.scala
@@ -94,7 +94,9 @@ object MesosClientExampleFramework {
     */
   def main(args: Array[String]): Unit = {
 
-    require((1 <= args.length) && (args.length <= 3), "Please provide arguments: <mesos-url> [<dcos-ca.crt>] [<private-key-file>]")
+    require(
+      (1 <= args.length) && (args.length <= 3),
+      "Please provide arguments: <mesos-url> [<dcos-ca.crt>] [<private-key-file>]")
 
     val akkaConfig: Config = ConfigFactory.parseString(s"""
       |akka.ssl-config.trustManager.stores = [

--- a/examples/mesos-client-example/src/test/scala/com/mesosphere/mesos/examples/MesosClientExampleFrameworkTest.scala
+++ b/examples/mesos-client-example/src/test/scala/com/mesosphere/mesos/examples/MesosClientExampleFrameworkTest.scala
@@ -11,7 +11,6 @@ class MesosClientExampleFrameworkTest extends AkkaUnitTest with MesosClusterTest
 
   override lazy val akkaConfig: Config = ConfigFactory.parseString(s"""
     |akka.test.default-timeout=${patienceConfig.timeout.millisPart}
-    |akka.ssl-config.trustManager.stores = [ { path: $${java.home}/lib/security/cacerts } ]
     """.stripMargin).withFallback(ConfigFactory.load()).resolve()
 
   "MesosClientExampleFramework should successfully connect to Mesos" in withFixture() { f =>


### PR DESCRIPTION
Summary:
Configures and packages the keep-alive-framework to run on struct
and thus on soak cluster.

Relates to mesosphere/soak-cluster-configurations#577.

JIRA issues: DCOS-47868