### PR TITLE
Publish USI Binaries to Mesosphere Maven Repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+git:
+  depth: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,9 @@ ansiColor('xterm') {
     }
   }
   node('jdk8-scala') {
-    stage('Publish') {
+    stage('Publish') { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-mesosphere-dev-jenkins']]) {
       checkout scm
       sh './gradlew publish --info'
-    } 
+    }}
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,11 @@ ansiColor('xterm') {
     }
   }
   node('jdk8-scala') {
-    stage('Publish') { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-mesosphere-dev-jenkins']]) {
+    stage('Publish') {
+      withCredentials([
+        string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
+        string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY'),
+      ]) {
       sshagent (credentials: ['0f7ec9c9-99b2-4797-9ed5-625572d5931d']) {
         checkout scm
         sh './gradlew publish --info'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ ansiColor('xterm') {
   node('jdk8-scala') {
     stage('Publish') {
       checkout scm
-      sh 'sudo -E ./gradlew publish --info'
+      sh './gradlew publish --info'
     } 
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+#!/usr/bin/env groovy
+
+@Library('sec_ci_libs@v2-latest') _
+
+def master_branches = ["master", ] as String[]
+
+ansiColor('xterm') {
+  // using shakedown node because it's a lightweight alpine docker image instead of full VM
+  node('shakedown') {
+    stage("Verify author") {
+      user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#eng-jenkins-builds')
+    }
+  }
+  node('jdk8-scala') {
+    stage('Publish') {
+      checkout scm
+      sh 'sudo -E ./gradlew publish --info'
+    } 
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,10 @@ ansiColor('xterm') {
   }
   node('jdk8-scala') {
     stage('Publish') { withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-mesosphere-dev-jenkins']]) {
-      checkout scm
-      sh './gradlew publish --info'
+      sshagent (credentials: ['0f7ec9c9-99b2-4797-9ed5-625572d5931d']) {
+        checkout scm
+        sh './gradlew publish --info'
+      }
     }}
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 import java.nio.file.Paths
 
 plugins {
@@ -32,6 +31,7 @@ allprojects {
 
     apply plugin: "scala"
     apply plugin: 'cz.alenkacz.gradle.scalafmt'
+    apply plugin: 'maven-publish'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -84,6 +84,28 @@ allprojects {
         reports.html.enabled = false
     }
     check {}
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId project.group
+                version project.version
+
+                from components.java
+            }
+        }
+        repositories {
+            maven {
+                def snapshotsRepoUrl = 's3://downloads.mesosphere.io/maven-snapshot/'
+                def releaseRepoUrl = 's3://downloads.mesosphere.io/maven/'
+                url = version.endsWith('-SNAPSHOT') ? snapshotsRepoUrl : releaseRepoUrl
+                authentication {
+                    awsIm(AwsImAuthentication)
+                }
+            }
+        }
+    }
+
 }
 
 apply from: 'ci.gradle'

--- a/ci.gradle
+++ b/ci.gradle
@@ -73,10 +73,8 @@ task ci {
 
     if (TravisEnvironment.isMasterBuild()) {
         dependsOn githubReport, gitPublishPush
-        dependsOn publishMavenJavaPublicationToMavenRepository
     } else if (TravisEnvironment.isSecureBuild())  {
         dependsOn githubReport
-        dependsOn publishMavenJavaPublicationToMavenRepository
     }
 
     // in CI we need to gather test results as a report. We use TestReport task for that

--- a/ci.gradle
+++ b/ci.gradle
@@ -73,8 +73,10 @@ task ci {
 
     if (TravisEnvironment.isMasterBuild()) {
         dependsOn githubReport, gitPublishPush
+        dependsOn publishMavenJavaPublicationToMavenRepository
     } else if (TravisEnvironment.isSecureBuild())  {
         dependsOn githubReport
+        dependsOn publishMavenJavaPublicationToMavenRepository
     }
 
     // in CI we need to gather test results as a report. We use TestReport task for that

--- a/core-models/build.gradle
+++ b/core-models/build.gradle
@@ -2,3 +2,9 @@ dependencies {
     compile "org.apache.mesos:mesos:$mesosVersion"
     testCompile project(':test-utils')
 }
+
+publishing.publications {
+    mavenJava(MavenPublication) {
+        artifactId 'core-models'
+    }
+}

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/FetchUri.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/FetchUri.scala
@@ -10,7 +10,7 @@ import java.net.URI
   * @param uri artifact URI to download
   * @param extract if true, the artifact will be treated as an archive an extracted to the sandbox. See the list
   *                of the supported archive types below
-  * @param executable if true, the fetch result will be changed to be executable (by “chmod”) for every user
+  * @param executable if true, the fetch result will be changed to be executable (by "chmod") for every user
   * @param cache if true, the fetcher cache is to be used for the URI
   * @param outputFile if set, the fetcher will use that name for the copy stored in the sandbox directory
   */

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,3 +12,9 @@ test {
         showStandardStreams = true
     }
 }
+
+publishing.publications {
+    mavenJava(MavenPublication) {
+        artifactId 'core'
+    }
+}

--- a/mesos-client/build.gradle
+++ b/mesos-client/build.gradle
@@ -8,3 +8,9 @@ dependencies {
     compile "de.heikoseeberger:akka-http-play-json_$scalaVersion:1.26.0"
     compile "org.apache.mesos:mesos:$mesosVersion"
 }
+
+publishing.publications {
+    mavenJava(MavenPublication) {
+        artifactId 'mesos-client'
+    }
+}

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosCalls.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosCalls.scala
@@ -38,7 +38,7 @@ class MesosCalls(frameworkId: FrameworkID) {
     * Sent by the scheduler when it accepts offer(s) sent by the master. The ACCEPT request includes the type
     * of operations (e.g., launch task, launch task group, reserve resources, create volumes) that the scheduler
     * wants to perform on the offers. Note that until the scheduler replies (accepts or declines) to an offer,
-    * the offer’s resources are considered allocated to the offer’s role and to the framework.
+    * the offer's resources are considered allocated to the offer's role and to the framework.
     *
     * http://mesos.apache.org/documentation/latest/scheduler-http-api/#accept
     */
@@ -116,7 +116,7 @@ class MesosCalls(frameworkId: FrameworkID) {
     *
     * Sent by the scheduler to kill a specific task. If the scheduler has a custom executor, the kill is forwarded
     * to the executor; it is up to the executor to kill the task and send a TASK_KILLED (or TASK_FAILED) update.
-    * If the task hasn’t yet been delivered to the executor when Mesos master or agent receives the kill request,
+    * If the task hasn't yet been delivered to the executor when Mesos master or agent receives the kill request,
     * a TASK_KILLED is generated and the task launch is not forwarded to the executor. Note that if the task belongs
     * to a task group, killing of one task results in all tasks in the task group being killed. Mesos releases the
     * resources for a task once it receives a terminal update for the task. If the task is unknown to the master,

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -131,7 +131,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
 
   /**
     * This is the first step in the communication process between the scheduler and the master. This is also to be
-    * considered as subscription to the “/scheduler” event stream. To subscribe with the master, the scheduler sends
+    * considered as subscription to the "/scheduler" event stream. To subscribe with the master, the scheduler sends
     * an HTTP POST with a SUBSCRIBE message including the required FrameworkInfo. Note that if
     * `subscribe.framework_info.id` is not set, master considers the scheduler as a new one and subscribes it by
     * assigning it a FrameworkID. The HTTP response is a stream in RecordIO format; the event stream begins with a

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -1,3 +1,9 @@
 dependencies {
     compile project(':core-models')
 }
+
+publishing.publications {
+    mavenJava(MavenPublication) {
+        artifactId 'persistence'
+    }
+}

--- a/version
+++ b/version
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Version script for USI
 #
 MAJOR=0


### PR DESCRIPTION
Summary:
This patch introduces a Jenkins job that publishes the USI binaries to our own
Maven repository. It uses the same credentials as the Marathon JAR publishing
job.