### PR TITLE
Start USI cli.

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,19 +1,14 @@
 plugins {
     id 'application'
-    id 'com.palantir.graal' version '0.4.0'
 }
 dependencies {
     compile project(':core')
     compile project(':mesos-client')
-    
+
     compile "de.heikoseeberger:akka-http-play-json_$scalaVersion:1.26.0"
+    compile "ch.qos.logback:logback-classic:1.2.3"
 }
 
 application {
     mainClassName = 'com.mesosphere.usi.cli.Main'
-}
-
-graal {
-    mainClass 'com.mesosphere.usi.cli.Main'
-    outputName 'usi'
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'application'
+    id 'com.palantir.graal' version '0.4.0'
+}
+dependencies {
+    compile project(':core')
+    compile project(':mesos-client')
+    
+    compile "de.heikoseeberger:akka-http-play-json_$scalaVersion:1.26.0"
+}
+
+application {
+    mainClassName = 'com.mesosphere.usi.cli.Main'
+}
+
+graal {
+    mainClass 'com.mesosphere.usi.cli.Main'
+    outputName 'usi'
+}

--- a/cli/src/main/scala/com/mesosphere/usi/cli/Main.scala
+++ b/cli/src/main/scala/com/mesosphere/usi/cli/Main.scala
@@ -1,0 +1,66 @@
+package com.mesosphere.usi.cli
+import java.net.URI
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.sse.ServerSentEvent
+import akka.http.scaladsl.unmarshalling.sse.EventStreamParser
+import akka.stream.scaladsl.{Sink, Source, StreamConverters}
+import akka.stream.{ActorMaterializer, IOResult, Materializer}
+import akka.util.ByteString
+import com.mesosphere.usi.core.models._
+import com.mesosphere.usi.core.models.resources.{ResourceRequirement, ResourceType, ScalarRequirement}
+import play.api.libs.json._
+
+import scala.concurrent.Future
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello")
+
+    implicit val sys: ActorSystem = ActorSystem("UsiCli")
+    implicit val mat: Materializer = ActorMaterializer()
+
+    def maxLineSize: Int = 4096
+    def maxEventSize: Int = 8192
+
+    val stdinSource: Source[ByteString, Future[IOResult]] = StreamConverters.fromInputStream(() => System.in)
+    val stdoutSink: Sink[ByteString, Future[IOResult]] = StreamConverters.fromOutputStream(() => System.out)
+
+    val parser = EventStreamParser(maxLineSize, maxEventSize)
+
+    stdinSource
+      .via(parser)
+      .map(parseCommand)
+      .map { cmd =>
+        println(s"Processing: $cmd")
+        ByteString("done.")
+      }
+      .runWith(stdoutSink)
+  }
+
+  def parseCommand(event: ServerSentEvent): SchedulerCommand = {
+    event.eventType
+      .getOrElse(throw new IllegalArgumentException("Command did not include event type"))
+      .toLowerCase match {
+      case "launchpod" => Json.parse(event.data).as[LaunchPod]
+      case "killpod" => Json.parse(event.data).as[KillPod]
+      case other => throw new IllegalArgumentException(s"Unknown scheduler command '$other'")
+    }
+  }
+
+  implicit val podIdRead: Reads[PodId] = Json.reads[PodId]
+  implicit val resourceTypeRead: Reads[ResourceType] = Reads {
+    case JsString(value) => JsSuccess(ResourceType.fromName(value))
+    case other => JsError("unknown resource type")
+  }
+  implicit val uriRead: Reads[URI] = Reads {
+    case JsString(value) => JsSuccess(new URI(value))
+    case other => JsError("unknown uri type")
+  }
+  implicit val fetchUriRead: Reads[FetchUri] = Json.reads[FetchUri]
+  implicit val resourceRequirementRead: Reads[ResourceRequirement] =
+    Json.reads[ScalarRequirement].map(_.asInstanceOf[ResourceRequirement]) // TODO: support RangeRequirement
+  implicit val runTemplateRead: Reads[RunTemplate] = Json.reads[RunTemplate]
+  implicit val launchPodRead: Reads[LaunchPod] = Json.reads[LaunchPod]
+  implicit val killPodRead: Reads[KillPod] = Json.reads[KillPod]
+}

--- a/cli/src/main/scala/com/mesosphere/usi/cli/Main.scala
+++ b/cli/src/main/scala/com/mesosphere/usi/cli/Main.scala
@@ -9,13 +9,13 @@ import akka.stream.{ActorMaterializer, IOResult, Materializer}
 import akka.util.ByteString
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.resources.{ResourceRequirement, ResourceType, ScalarRequirement}
+import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json._
 
 import scala.concurrent.Future
 
-object Main {
+object Main extends StrictLogging {
   def main(args: Array[String]): Unit = {
-    println("Hello")
 
     implicit val sys: ActorSystem = ActorSystem("UsiCli")
     implicit val mat: Materializer = ActorMaterializer()
@@ -31,14 +31,16 @@ object Main {
     stdinSource
       .via(parser)
       .map(parseCommand)
+      .log("command")
       .map { cmd =>
-        println(s"Processing: $cmd")
+        logger.info(s"Processing: $cmd")
         ByteString("done.")
       }
       .runWith(stdoutSink)
   }
 
   def parseCommand(event: ServerSentEvent): SchedulerCommand = {
+    logger.info(s"parsing $event")
     event.eventType
       .getOrElse(throw new IllegalArgumentException("Command did not include event type"))
       .toLowerCase match {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'usi'
 
+include 'cli'
 include 'core'
 include 'core-models'
 include 'mesos-client'

--- a/usi.py
+++ b/usi.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger('usi')
+
+import asyncio
+import json
+
+async def usi():
+    logger.info("Starting USI cli...")
+
+    proc = await asyncio.create_subprocess_exec(
+        "cli-0.1/bin/cli",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+
+
+    launch_pod = {
+        "podId": { "value":"my_pod" },
+        "runSpec": { "shellCommand":"sleep 3600", "role":"foo", "resourceRequirements": [], "fetch": []}
+    }
+    scheduler_command = "event:launchpod\ndata:{}\n\n".format(json.dumps(launch_pod)).encode('utf-8')
+    proc.stdin.write(scheduler_command)
+    await proc.stdin.drain()
+    while True:
+       logger.info(await proc.stdout.readline())
+
+def main():
+    asyncio.run(usi())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
The CLI consumer scheduler commands via stdin and outputs pod events via
stdout. nput and output should be encoded in Server Sent Events.