### PR TITLE
Introduce and use version script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,20 @@ ext {
     akkaVersion = '2.5.19'
 }
 
+def readCurrentVersion = {
+  def out = new ByteArrayOutputStream()
+
+  exec{
+      commandLine "./version"
+      standardOutput = out;
+  }
+  out.toString().replaceAll("\\s", "");
+}
+
 allprojects {
 
     group = 'com.mesosphere.usi'
-    version = '0.1'
+    version = readCurrentVersion()
 
     apply plugin: "scala"
     apply plugin: 'cz.alenkacz.gradle.scalafmt'

--- a/version
+++ b/version
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Version script for USI
+#
+MAJOR=0
+MINOR=1
+BRANCH_POINT=8f32d291
+REF=HEAD
+CANON=origin/master
+REV=$(git rev-parse $REF)
+
+declare -a OTHERARGS
+help() {
+  cat <<-EOF
+Usage $0 [options]
+
+  --help This help
+  --ref  The reference for which version to output Defaults to HEAD
+
+Non-arg params
+
+* commit - output just the formatted commit hash
+* package - output the version with the commit hash, ie 1.9.34-a122edcb4
+
+EOF
+}
+
+while ! [ -z "$1" ]; do
+  arg="$1"
+  shift
+  case "$arg" in
+    --help)
+      help
+      exit 0
+      ;;
+    --ref)
+      REF="$1"
+      shift
+      ;;
+    *)
+      OTHERARGS+=("$arg")
+      ;;
+  esac
+done
+
+# Infer version
+# Number of commits since branch point
+IS_DIRECT_CHILD=$( git log $CANON..$BRANCH_POINT)
+
+MERGE_BASE=$(git merge-base $REF $CANON)
+COMMIT_NUMBER="$(git rev-list --count --first-parent $BRANCH_POINT..$MERGE_BASE)"
+COMMIT_HASH=${REV::7}
+
+if [ "$MERGE_BASE" == "$REV" ]; then
+  SNAPSHOT_INFO=""
+else
+  SNAPSHOT_INFO="-${COMMIT_HASH}-SNAPSHOT"
+fi
+
+
+case ${OTHERARGS[0]} in
+  commit)
+    # Echo commit hash
+    echo "$COMMIT_HASH"
+    ;;
+  "")
+    # Echo version
+    # E.g. 1.7.42
+    echo "$MAJOR.$MINOR.$COMMIT_NUMBER${SNAPSHOT_INFO}"
+    ;;
+  *)
+    echo "ERROR: ${OTHERARGS[0]} is not a version format"
+    echo
+    help
+    exit 1
+    ;;
+
+
+esac


### PR DESCRIPTION
This version script aids with auto-versionining USI by counting the number of commits to master since some point in the history.

Commits not-yet-merged to master are versioned by counting the number of
commits since their merge-base (the point of deviation); further, commits
not-yet-merged are treated as snapshot. If origin/master is at version 0.1.15,
and tharper/some-new-feature deviated two commits before origin/master, it's
version will be 0.1.13-deadbee-SNAPSHOT.