### PR TITLE
Support Mesos 1.9 in tests.

### DIFF
--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
@@ -34,7 +34,6 @@ case class Session(url: URL, streamId: String, authorization: Option[Credentials
     * @return The [[HttpRequest]] with proper headers and body.
     */
   def createPostRequest(bytes: Array[Byte], maybeCredentials: Option[HttpCredentials]): HttpRequest = {
-    println(s"Body: ${bytes.map(_.toChar).mkString}")
     HttpRequest(
       HttpMethods.POST,
       uri = Uri(s"$url/api/v1/scheduler"),

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
@@ -111,7 +111,7 @@ class MesosFacade(val url: URL, val waitTime: FiniteDuration = 30.seconds)(
   // `waitTime` is passed implicitly to the `request` and `requestFor` methods
   implicit val requestTimeout = waitTime
   def state: RestResult[ITMesosState] = {
-    result(requestFor[ITMesosState](Get(s"$url/state.json")), waitTime)
+    result(requestFor[ITMesosState](Get(s"$url/state")), waitTime)
   }
 
   def frameworks(): RestResult[ITFrameworks] = {


### PR DESCRIPTION
Summary:
We query `/state.json` but that endpoint has been removed.