### PR TITLE
Do not close namespaced Zookeeper client.

### DIFF
--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosClusterExtension.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosClusterExtension.scala
@@ -62,9 +62,7 @@ object MesosClusterExtension {
 
     private[mesos] var suiteName: String = "unknown"
     private[mesos] var mesosMasterZkUrl: String = null
-    private[mesos] var mesosNumMasters = 1
-    private[mesos] var mesosNumAgents = 1
-    private[mesos] var mesosQuorumSize = 1
+    private[mesos] var config = new MesosConfig()
     private[mesos] var agentConfig = new MesosAgentConfig("posix", "mesos", Option.empty, Option.empty)
     private[mesos] var mesosLeaderTimeout = new FiniteDuration(30, TimeUnit.SECONDS)
 
@@ -85,19 +83,19 @@ object MesosClusterExtension {
 
     /** @return the builder with the number of masters updated to {{{num}}}. Defaults to 1. */
     def withNumMasters(num: Int): Builder = {
-      this.mesosNumMasters = num
+      this.config = this.config.copy(numMasters = num)
       this
     }
 
     /** @return the builder with the number of agents updated to {{{num}}}. Defaults to 1. */
     def withNumAgents(num: Int): Builder = {
-      this.mesosNumAgents = num
+      this.config = this.config.copy(numAgents = num)
       this
     }
 
     /** @return the builder with the Mesos quorum size updated to {{{num}}}. Defaults to 1. */
     def withQuorumSize(num: Int): Builder = {
-      this.mesosQuorumSize = num
+      this.config = this.config.copy(quorumSize = num)
       this
     }
 
@@ -129,16 +127,11 @@ object MesosClusterExtension {
     def build(system: ActorSystem, materializer: Materializer): MesosClusterExtension = {
       val mesosCluster = new MesosCluster(
         suiteName,
-        mesosNumMasters,
-        mesosNumAgents,
         mesosMasterZkUrl,
-        mesosQuorumSize,
         false,
+        config,
         agentConfig,
         mesosLeaderTimeout,
-        mastersFaultDomains,
-        agentsFaultDomains,
-        agentsGpus
       )(system, materializer)
 
       new MesosClusterExtension(mesosCluster)

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
@@ -149,10 +149,14 @@ class MesosFacade(val url: URL, val waitTime: FiniteDuration = 30.seconds)(
     * @return Right(Done) on success, Left(errorString) otherwise
     */
   def markAgentGone(agentId: String): RestResult[Done] = {
-    val response = result(request(Post(s"$url/api/v1", Json.obj(
-      "type" -> "MARK_AGENT_GONE",
-      "mark_agent_gone" -> Json.obj(
-        "agent_id" -> Json.obj("value" -> agentId))))), waitTime)
+    val response = result(
+      request(
+        Post(
+          s"$url/api/v1",
+          Json.obj(
+            "type" -> "MARK_AGENT_GONE",
+            "mark_agent_gone" -> Json.obj("agent_id" -> Json.obj("value" -> agentId))))),
+      waitTime)
     response.map { _ =>
       Done
     }

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
@@ -89,7 +89,7 @@ object MesosFacade {
 
   case class ITask(id: String, name: String, framework_id: String, state: Option[String])
 
-  case class ITFramework(id: String, name: String, active: Boolean, connected: Boolean, tasks: Seq[ITask])
+  case class ITFramework(id: String, name: String, active: Boolean, connected: Boolean, tasks: Seq[ITask], unreachable_tasks: Seq[ITask])
 
   case class ITFrameworks(
       frameworks: Seq[ITFramework],

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -37,42 +37,73 @@ case class MesosAgentConfig(
     imageProviders: Option[String] = None)
 
 /**
+  *
+  * @param numMasters number of Mesos master
+  * @param numAgents number of Mesos agents
+  * @param quorumSize Mesos master quorum size
+  * @param launcher
+  * @param containerizers
+  * @param isolation
+  * @param imageProviders
+  * @param mastersFaultDomains Mesos master fault domain configuration
+  * @param agentsFaultDomains Mesos agents fault domain configuration
+  * @param agentsGpus number of GPUs per agent
+  * @param agentSeccompConfigDir
+  * @param agentSeccompProfileName
+  * @param restrictedToRoles
+  */
+case class MesosConfig(
+    numMasters: Int = 1,
+    numAgents: Int = 1,
+    quorumSize: Int = 1,
+    launcher: String = "posix",
+    containerizers: String = "mesos",
+    isolation: Option[String] = None,
+    imageProviders: Option[String] = None,
+    mastersFaultDomains: Seq[Option[FaultDomain]] = Seq.empty,
+    agentsFaultDomains: Seq[Option[FaultDomain]] = Seq.empty,
+    agentsGpus: Option[Int] = None, // TODO: move agent related config into MesosAgentConfig
+    agentSeccompConfigDir: Option[String] = None,
+    agentSeccompProfileName: Option[String] = None,
+    restrictedToRoles: Option[String] = Some("public,foo")) {
+
+  require(validQuorumSize, "Mesos quorum size should be 0 or smaller than number of agents")
+  require(
+    validSeccompConfig,
+    "To enable seccomp, agentSeccompConfigDir should be defined and isolation \"linux/seccomp\" used")
+  require(validFaultDomainConfig, "Fault domains should be configure for all agents or not at all")
+
+  def validQuorumSize: Boolean = quorumSize > 0 && quorumSize <= numMasters
+  def validFaultDomainConfig: Boolean = agentsFaultDomains.isEmpty || agentsFaultDomains.size == numAgents
+  def validSeccompConfig: Boolean =
+    agentSeccompConfigDir.isEmpty || (agentSeccompConfigDir.isDefined && isolation.get.contains("linux/seccomp"))
+}
+
+/**
   * Basic class that wraps starting/stopping a Mesos cluster with passed agent/master configuration and configurable
   * number of masters/agents.
   *
   * @param suiteName suite name that uses the cluster. will be included into logging messages
-  * @param numMasters number of Mesos master
-  * @param numSlaves number of Mesos slaves
   * @param masterUrl Mesos master ZK url in the form of zk://zk-1/mesos
-  * @param quorumSize Mesos master quorum size
   * @param autoStart if true, the cluster will be started automatically
+  * @param config Mesos master configuration
   * @param agentsConfig Mesos agent configuration
   * @param waitForMesosTimeout time to wait for Mesos master/agent to start
-  * @param mastersFaultDomains Mesos master fault domain configuration
-  * @param agentsFaultDomains Mesos agents fault domain configuration
-  * @param agentsGpus number of GPUs per agent
   */
 case class MesosCluster(
     suiteName: String,
-    numMasters: Int,
-    numSlaves: Int,
     masterUrl: String,
-    quorumSize: Int = 1,
     autoStart: Boolean = false,
+    config: MesosConfig = MesosConfig(),
     agentsConfig: MesosAgentConfig = MesosAgentConfig(),
-    waitForMesosTimeout: FiniteDuration = 5.minutes,
-    mastersFaultDomains: Seq[Option[FaultDomain]],
-    agentsFaultDomains: Seq[Option[FaultDomain]],
-    agentsGpus: Option[Int] = None)(implicit system: ActorSystem, mat: Materializer)
+    waitForMesosTimeout: FiniteDuration = 5.minutes)(implicit system: ActorSystem, mat: Materializer)
     extends AutoCloseable
     with Eventually
     with StrictLogging {
-  require(quorumSize > 0 && quorumSize <= numMasters)
-  require(agentsFaultDomains.isEmpty || agentsFaultDomains.size == numSlaves)
 
-  lazy val masters: Seq[Master] = 0.until(numMasters).map { i =>
-    val faultDomainJson = if (mastersFaultDomains.nonEmpty && mastersFaultDomains(i).nonEmpty) {
-      val faultDomain = mastersFaultDomains(i).get
+  lazy val masters: Seq[Master] = 0.until(config.numMasters).map { i =>
+    val faultDomainJson = if (config.mastersFaultDomains.nonEmpty && config.mastersFaultDomains(i).nonEmpty) {
+      val faultDomain = config.mastersFaultDomains(i).get
       val faultDomainJson = s"""
                                |{
                                |  "fault_domain":
@@ -91,15 +122,17 @@ case class MesosCluster(
       Some(faultDomainJson)
     } else None
 
-    Master(
-      extraArgs = Seq("--agent_ping_timeout=1secs", "--max_agent_ping_timeouts=4", s"--quorum=$quorumSize") ++ faultDomainJson
-        .map(fd => s"--domain=$fd"))
+    Master(extraArgs = Seq(
+      "--agent_ping_timeout=1secs",
+      "--max_agent_ping_timeouts=4",
+      s"--quorum=${config.quorumSize}") ++ faultDomainJson
+      .map(fd => s"--domain=$fd"))
   }
 
-  lazy val agents: Seq[Agent] = 0.until(numSlaves).map { i =>
+  lazy val agents: Seq[Agent] = 0.until(config.numAgents).map { i =>
     val (faultDomainAgentAttributes: Map[String, Option[String]], mesosFaultDomainAgentCmdOption) =
-      if (agentsFaultDomains.nonEmpty && agentsFaultDomains(i).nonEmpty) {
-        val faultDomain = agentsFaultDomains(i).get
+      if (config.agentsFaultDomains.nonEmpty && config.agentsFaultDomains(i).nonEmpty) {
+        val faultDomain = config.agentsFaultDomains(i).get
         val mesosFaultDomainCmdOption = s"""
                                          |{
                                          |  "fault_domain":
@@ -135,7 +168,7 @@ case class MesosCluster(
     // First-come-first-served task will bind successfully where the others will fail leading to a lot inconsistency and
     // flakiness in tests.
     Agent(
-      resources = new Resources(ports = PortAllocator.portsRange(), gpus = agentsGpus),
+      resources = new Resources(ports = PortAllocator.portsRange(), gpus = config.agentsGpus),
       extraArgs = Seq(
         s"--attributes=$renderedAttributes"
       ) ++ mesosFaultDomainAgentCmdOption.map(fd => s"--domain=$fd")
@@ -370,23 +403,16 @@ trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest wit
   def agentsGpus: Option[Int] = None
 
   lazy val mesosMasterZkUrl = s"zk://${zkserver.connectUrl}/mesos"
-  lazy val mesosNumMasters = 1
-  lazy val mesosNumSlaves = 1
-  lazy val mesosQuorumSize = 1
+  lazy val mesosConfig = MesosConfig()
   lazy val agentConfig = MesosAgentConfig()
   lazy val mesosLeaderTimeout: FiniteDuration = patienceConfig.timeout.toMillis.milliseconds
   lazy val mesosCluster = MesosCluster(
     suiteName,
-    mesosNumMasters,
-    mesosNumSlaves,
     mesosMasterZkUrl,
-    mesosQuorumSize,
     autoStart = false,
+    config = mesosConfig,
     agentsConfig = agentConfig,
-    mesosLeaderTimeout,
-    mastersFaultDomains,
-    agentsFaultDomains,
-    agentsGpus = agentsGpus
+    waitForMesosTimeout = mesosLeaderTimeout,
   )
   lazy val mesosFacade = new MesosFacade(mesosCluster.waitForLeader())
 

--- a/test-utils/src/main/scala/com/mesosphere/utils/zookeeper/ZookeeperServer.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/zookeeper/ZookeeperServer.scala
@@ -104,7 +104,10 @@ trait ZookeeperServerTest extends BeforeAndAfterAll with StrictLogging { this: S
       throw new IllegalStateException("Failed to connect to Zookeeper. Will exit now.")
     }
     val namespaced = namespace.map(client.usingNamespace(_)).getOrElse(client)
-    zkclients.add(namespaced)
+
+    // No need to add the namespaced client to the list - it's just a facade for the underlying one
+    zkclients.add(client)
+
     namespaced
   }
 


### PR DESCRIPTION
Summary:
This fixes the USI test utils migration in mesosphere/marathon#7084. The
original fixture in Marathon would not close the namespaced client but
the underlying Zookeeper client.