### PR TITLE
Configure Mesos role for keep-alive-framework.

### DIFF
--- a/examples/keep-alive-framework/README.md
+++ b/examples/keep-alive-framework/README.md
@@ -12,17 +12,19 @@ Run the keep-alive example framework that:
    ```
    dcos security org service-accounts keypair usi.private.pem usi.pub.pem
    ```
-3. Create user `strict-usi`:
+3. Create user `usi`:
    ```
-   dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" strict-usi
+   dcos security org service-accounts create -p usi.pub.pem -d "For testing USI on strict" usi
    ```
 4. Store private key as secret:
    ```
    dcos security secrets create -f ./usi.private.pem usi/private_key
    ```
-5. Grant `strict-usi` access:
+5. Grant `usi` access:
    ```
-   dcos security org users grant strict-usi dcos:mesos:master:task:user:nobody create
+   dcos security org users grant usi dcos:mesos:master:task:user:nobody create
+   dcos security org users grant usi dcos:mesos:master:framework:role:usi read
+   dcos security org users grant usi dcos:mesos:master:framework:role:usi create
    ```
 6. Deploy the framework:
    ```

--- a/examples/keep-alive-framework/build.gradle
+++ b/examples/keep-alive-framework/build.gradle
@@ -11,6 +11,7 @@ application {
 dependencies {
     implementation project(':core')
     implementation project(':persistence')
+    implementation group: 'com.github.scopt', name: "scopt_$scalaVersion", version: '4.0.0-RC2'
 
     // Use testCompile when we add implementation project(':persistence-zookeeper')
     implementation project(':test-utils')

--- a/examples/keep-alive-framework/keep-alive-framework-app.json
+++ b/examples/keep-alive-framework/keep-alive-framework-app.json
@@ -4,7 +4,7 @@
   "id": "/usi/keep-alive-framework",
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
-  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/amazon-corretto*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework https://master.mesos https://leader.mesos:5050 $MESOS_SANDBOX/.ssl/ca-bundle.crt $MESOS_SANDBOX/private_key.pem strict-usi",
+  "cmd": "export JAVA_HOME=$(ls -d $MESOS_SANDBOX/amazon-corretto*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\"; ./keep-alive-framework-0.1/bin/keep-alive-framework --dcos-url https://master.mesos --mesos-url https://leader.mesos:5050 --dcos-ca.cert $MESOS_SANDBOX/.ssl/ca-bundle.crt --private-key-file $MESOS_SANDBOX/private_key.pem --iam-uid strict-usi --msos-role usi",
   "container": {
     "type": "MESOS",
     "volumes": [

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
@@ -95,17 +95,16 @@ class KeepAliveFramework(settings: KeepAliveFrameWorkSettings, authorization: Op
       +-----------------------+
 
     */
-  source
+  val end = source
     .via(keepAliveWatcher)
     .prepend(Source(specsSnapshot.map { spec =>
       LaunchPod(spec.id, spec.runSpec)
     }))
-    .to(sink)
-    .run()
+    .runWith(sink)
 
   // We let the framework run "forever"
-  io.StdIn.readLine("Keep alive framework is started")
-
+  val result = Await.result(end, Duration.Inf)
+  logger.warn(s"Framework finished with $result")
 }
 
 object KeepAliveFramework {

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveMesosClientFactory.scala
@@ -13,15 +13,16 @@ import scala.concurrent.Await
 /**
   * Helper that builds a Mesos client that can be used by USI
   */
-class KeepAliveMesosClientFactory(settings: MesosClientSettings, authorization: Option[CredentialsProvider])(
-    implicit system: ActorSystem,
-    mat: ActorMaterializer) {
+class KeepAliveMesosClientFactory(
+    settings: MesosClientSettings,
+    authorization: Option[CredentialsProvider],
+    role: String)(implicit system: ActorSystem, mat: ActorMaterializer) {
 
   val frameworkInfo = FrameworkInfo
     .newBuilder()
     .setUser("nobody")
     .setName("KeepAliveFramework")
-    .addRoles("test")
+    .addRoles(role)
     .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
     .setFailoverTimeout(0d)
     .build()


### PR DESCRIPTION
Summary:
The example framework cannot run on strict because we hard coded the
Mesos role. With this patch it becomes optional. We also introduce a
command line argument parser.