### PR TITLE
Produce basic metrics.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile project(':core-models')
     compile project(':persistence')
     compile project(':mesos-client')
+    compile project(':metrics')
     testCompile project(':test-utils')
 }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -82,6 +82,7 @@ private[core] class SchedulerLogicHandler(mesosCallFactory: MesosCalls, initialS
   private var state: SchedulerState = SchedulerState.fromSnapshot(initialState)
 
   def handleCommand(command: SchedulerCommand): SchedulerEvents = {
+    metrics.meter(s"usi.scheduler.command.${command.getClass}").mark()
     handleFrame { builder =>
       builder.process { (state, _) =>
         schedulerLogic.handleCommand(state)(command)

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerLogicHandlerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerLogicHandlerTest.scala
@@ -17,6 +17,7 @@ import com.mesosphere.usi.core.models.{
 }
 import com.mesosphere.usi.core.protos.ProtoBuilders
 import com.mesosphere.utils.UnitTest
+import com.mesosphere.utils.metrics.DummyMetrics
 import org.apache.mesos.v1.scheduler.Protos.Call
 import org.apache.mesos.v1.{Protos => Mesos}
 import org.scalatest.Inside
@@ -61,7 +62,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
 
     "ignore launch commands for podIds that already have a podRecord" in {
       Given("the scheduler logic already has launched a pod")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
       handler.handleCommand(launchPod)
 
       inside(handler.handleMesosEvent(newOfferEvent(offer))) {
@@ -83,7 +85,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
     }
 
     "match a valid offer and reports a running task" in {
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
       handler.handleCommand(launchPod)
 
       inside(handler.handleMesosEvent(newOfferEvent(offer))) {
@@ -115,7 +118,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
 
     "emits a unrecognized podStatus and acknowledges a task status when receiving a task status for a record-less pod" in {
       Given("Scheduler logic handler with empty state")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
 
       When("a task status update is received")
       val result = handler.handleMesosEvent(newTaskUpdateEvent(runningTaskStatus))
@@ -139,7 +143,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
 
     "removes unrecognized podStatuses when they become terminal" in {
       Given("Scheduler logic handler with a unrecognized podStatus state")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
 
       When("a unrecognized task status update is received")
       val resultForRunningTaskStatus = handler.handleMesosEvent(newTaskUpdateEvent(runningTaskStatus))
@@ -171,7 +176,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
 
     "removes TerminalPodSpecs when they are reported terminal" in {
       Given("Scheduler logic handler with a unrecognized podStatus state")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
       handler.handleMesosEvent(newTaskUpdateEvent(runningTaskStatus))
 
       And("the task status turns back to terminal")
@@ -201,7 +207,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
   "suppress and revive logic" should {
     "produces a Mesos revive call for a newly launched podSpec's role" in {
       Given("Scheduler logic handler with empty state")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
       val podId = PodId("pod")
 
       When("pod with role 'test-role' is launched")
@@ -224,7 +231,8 @@ class SchedulerLogicHandlerTest extends UnitTest with Inside {
 
     "produces a Mesos suppress call when all podSpecs for a given role are launched" in {
       Given("Scheduler logic handler with not launched pod")
-      val handler = new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty)
+      val handler =
+        new SchedulerLogicHandler(new MesosCalls(MesosMock.mockFrameworkId), StateSnapshot.empty, DummyMetrics)
       val podId = PodId("pod")
       // creates not launched pod in the internal state of scheduler logic
       handler.handleCommand(commands.LaunchPod(podId, testRoleRunSpec))

--- a/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/SchedulerTest.scala
@@ -13,6 +13,7 @@ import com.mesosphere.usi.core.helpers.SchedulerStreamTestHelpers.commandInputSo
 import com.mesosphere.usi.core.models.commands.SchedulerCommand
 import com.mesosphere.usi.core.models.{AgentId, PodId, PodRecord, PodRecordUpdatedEvent, StateEvent}
 import com.mesosphere.utils.AkkaUnitTest
+import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
 import org.scalatest._
@@ -42,6 +43,7 @@ class SchedulerTest extends AkkaUnitTest with Inside {
         .unconnectedGraph(
           new MesosCalls(MesosMock.mockFrameworkId),
           InMemoryPodRecordRepository(),
+          DummyMetrics,
           SchedulerSettings.load())
         .futureValue
     Flow.fromGraph {

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -13,6 +13,7 @@ import com.mesosphere.usi.core.models.resources.{RangeRequirement, ScalarRequire
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory
 import com.mesosphere.utils.AkkaUnitTest
 import com.mesosphere.utils.mesos.MesosClusterTest
+import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.Protos
 import org.apache.mesos.v1.Protos.FrameworkInfo
@@ -32,7 +33,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
 
   lazy val mesosClient: MesosClient = MesosClient(settings, frameworkInfo).runWith(Sink.head).futureValue
   lazy val (snapshot, schedulerFlow) =
-    Scheduler.fromClient(mesosClient, InMemoryPodRecordRepository(), SchedulerSettings.load()).futureValue
+    Scheduler.fromClient(mesosClient, InMemoryPodRecordRepository(), DummyMetrics, SchedulerSettings.load()).futureValue
   lazy val (input, output) = commandInputSource
     .via(schedulerFlow)
     .toMat(Sink.queue())(Keep.both)

--- a/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/logic/MesosEventsLogicTest.scala
@@ -9,11 +9,12 @@ import com.mesosphere.usi.core.models.resources.{ResourceRequirement, ResourceTy
 import com.mesosphere.usi.core.models.template.{RunTemplate, SimpleRunTemplateFactory}
 import com.mesosphere.usi.core.protos.ProtoBuilders.{newAgentId, newTaskStatus}
 import com.mesosphere.utils.UnitTest
+import com.mesosphere.utils.metrics.DummyMetrics
 import org.apache.mesos.v1.{Protos => Mesos}
 
 class MesosEventsLogicTest extends UnitTest {
 
-  private val mesosEventLogic = new MesosEventsLogic(new MesosCalls(MesosMock.mockFrameworkId))
+  private val mesosEventLogic = new MesosEventsLogic(new MesosCalls(MesosMock.mockFrameworkId), DummyMetrics)
 
   def testRunTemplate(cpus: Int = Integer.MAX_VALUE, mem: Int = 256): RunTemplate = {
     val resourceRequirements = List.newBuilder[ResourceRequirement]

--- a/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
+++ b/examples/core-hello-world/src/main/scala/com/mesosphere/usi/examples/CoreHelloWorldFramework.scala
@@ -15,6 +15,7 @@ import com.mesosphere.usi.core.models.resources.ScalarRequirement
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory
 import com.mesosphere.usi.core.models.{PodId, PodStatus, PodStatusUpdatedEvent, StateEvent, StateSnapshot, commands}
 import com.mesosphere.usi.repository.PodRecordRepository
+import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.Protos.{FrameworkID, FrameworkInfo, TaskState, TaskStatus}
@@ -124,7 +125,9 @@ object CoreHelloWorldFramework extends StrictLogging {
       materializer: Materializer): (MesosClient, StateSnapshot, Flow[SchedulerCommand, StateEvent, NotUsed]) = {
     val client: MesosClient = Await.result(MesosClient(clientSettings, frameworkInfo).runWith(Sink.head), 10.seconds)
     val (snapshot, schedulerFlow) =
-      Await.result(Scheduler.fromClient(client, podRecordRepository, SchedulerSettings.load()), 10.seconds)
+      Await.result(
+        Scheduler.fromClient(client, podRecordRepository, DummyMetrics, SchedulerSettings.load()),
+        10.seconds)
     (client, snapshot, schedulerFlow)
   }
 

--- a/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
+++ b/examples/keep-alive-framework/src/main/scala/com/mesosphere/usi/helloworld/KeepAliveFramework.scala
@@ -14,6 +14,7 @@ import com.mesosphere.usi.core.conf.SchedulerSettings
 import com.mesosphere.usi.core.models.{commands, _}
 import com.mesosphere.usi.core.models.commands.{ExpungePod, LaunchPod, SchedulerCommand}
 import com.mesosphere.usi.core.models.template.RunTemplate
+import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
@@ -69,7 +70,9 @@ class KeepAliveFramework(settings: KeepAliveFrameWorkSettings, authorization: Op
   val podRecordRepository = InMemoryPodRecordRepository()
 
   val (stateSnapshot, source, sink) =
-    Await.result(Scheduler.asSourceAndSink(client, podRecordRepository, SchedulerSettings.load()), 10.seconds)
+    Await.result(
+      Scheduler.asSourceAndSink(client, podRecordRepository, DummyMetrics, SchedulerSettings.load()),
+      10.seconds)
 
   /**
     * This is the core part of this framework. Source with SpecEvents is pushing events to the keepAliveWatcher,

--- a/metrics-dropwizard/build.gradle
+++ b/metrics-dropwizard/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(':metrics')
+    compile project(':metrics')
     testCompile project(':test-utils')
 
     compile group: 'com.github.vladimir-bukhtoyarov', name: 'rolling-metrics', version:  '2.0.4'


### PR DESCRIPTION
Summary:
USI will consome a `Metrics` implementation and report the following
metrics

Meters
* `usi.scheduler.offer.decline`
* `usi.scheduler.offer.decline.<agent-id>`
* `usi.scheduler.offer.processed`
* `usi.scheduler.offer.processed.<agent-id>`
* `usi.scheduler.offers.received`
* `usi.scheduler.offers.received.<agent-id>`
* `usi.scheduler.offers.revive.<role>`
* `usi.scheduler.offers.suppress.<role>`

Counters
* `usi.scheduler.operation.launch`

Timers
* `usi.scheduler.offer.processing`

JIRA issues: DCOS_OSS-5625