### PR TITLE
Configure executor registration timeout.

### DIFF
--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -12,7 +12,7 @@ import com.mesosphere.usi.core.models.commands.LaunchPod
 import com.mesosphere.usi.core.models.resources.{RangeRequirement, ScalarRequirement}
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory
 import com.mesosphere.utils.AkkaUnitTest
-import com.mesosphere.utils.mesos.MesosClusterTest
+import com.mesosphere.utils.mesos.{MesosAgentConfig, MesosClusterTest}
 import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.Protos

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -12,7 +12,7 @@ import com.mesosphere.usi.core.models.commands.LaunchPod
 import com.mesosphere.usi.core.models.resources.{RangeRequirement, ScalarRequirement}
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory
 import com.mesosphere.utils.AkkaUnitTest
-import com.mesosphere.utils.mesos.{MesosAgentConfig, MesosClusterTest}
+import com.mesosphere.utils.mesos.MesosClusterTest
 import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.Protos

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -178,8 +178,8 @@ case class MesosCluster(
       ) ++ mesosFaultDomainAgentCmdOption.map(fd => s"--domain=$fd")
         ++ agentsConfig.seccompConfigDir.map(dir => s"--seccomp_config_dir=$dir")
         ++ agentsConfig.seccompProfileName.map(prf => s"--seccomp_profile_name=$prf")
-        ++ agentsConfig.executorRegistrationTimeout.map(t => s"--executor_registration_timeout=${t.toMinutes}mins")
-        ++ agentsConfig.fetcherStallTimeout.map(t => s"--fetcher_stall_timeout=${t.toMinutes}mins")
+        ++ agentsConfig.executorRegistrationTimeout.map(t => s"--executor_registration_timeout=${t.toSeconds}secs")
+        ++ agentsConfig.fetcherStallTimeout.map(t => s"--fetcher_stall_timeout=${t.toSeconds}secs")
     )
   }
 

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -44,8 +44,10 @@ case class MesosAgentConfig(
     executorRegistrationTimeout: Option[Duration] = None,
     fetcherStallTimeout: Option[Duration] = None) {
 
-  require(executorRegistrationTimeout.getOrElse(1.minute) >= fetcherStallTimeout.getOrElse(1.minute),
-    s"Executor registration timeout $executorRegistrationTimeout must be bigger than fetcher stall timout $fetcherStallTimeout.")
+  require(
+    executorRegistrationTimeout.getOrElse(1.minute) >= fetcherStallTimeout.getOrElse(1.minute),
+    s"Executor registration timeout $executorRegistrationTimeout must be bigger than fetcher stall timout $fetcherStallTimeout."
+  )
 
   require(
     validSeccompConfig,

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -178,8 +178,8 @@ case class MesosCluster(
       ) ++ mesosFaultDomainAgentCmdOption.map(fd => s"--domain=$fd")
         ++ agentsConfig.seccompConfigDir.map(dir => s"--seccomp_config_dir=$dir")
         ++ agentsConfig.seccompProfileName.map(prf => s"--seccomp_profile_name=$prf")
-        ++ agentsConfig.executorRegistrationTimeout.map(t => s"--executor_registration_timeout=${t.toMinutes}")
-        ++ agentsConfig.fetcherStallTimeout.map(t => s"--fetcher_stall_timeout=${t.toMinutes}")
+        ++ agentsConfig.executorRegistrationTimeout.map(t => s"--executor_registration_timeout=${t.toMinutes}mins")
+        ++ agentsConfig.fetcherStallTimeout.map(t => s"--fetcher_stall_timeout=${t.toMinutes}mins")
     )
   }
 

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -179,7 +179,7 @@ case class MesosCluster(
         ++ agentsConfig.seccompConfigDir.map(dir => s"--seccomp_config_dir=$dir")
         ++ agentsConfig.seccompProfileName.map(prf => s"--seccomp_profile_name=$prf")
         ++ agentsConfig.executorRegistrationTimeout.map(t => s"--executor_registration_timeout=${t.toMinutes}")
-        ++ agentsConfig.fetcherStallTimeout.map(t => s"fetcher_stall_timeout=${t.toMinutes}")
+        ++ agentsConfig.fetcherStallTimeout.map(t => s"--fetcher_stall_timeout=${t.toMinutes}")
     )
   }
 

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -46,7 +46,7 @@ case class MesosAgentConfig(
 
   require(
     executorRegistrationTimeout.getOrElse(1.minute) >= fetcherStallTimeout.getOrElse(1.minute),
-    s"Executor registration timeout $executorRegistrationTimeout must be bigger than fetcher stall timout $fetcherStallTimeout."
+    s"Executor registration timeout $executorRegistrationTimeout must be bigger or equal than fetcher stall timeout $fetcherStallTimeout."
   )
 
   require(


### PR DESCRIPTION
Summary:
If the executor needs too long to download a Docker image it's killed.
This should enable stabilizing tests.