### PR TITLE
Simplify scheduler construction.

### DIFF
--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/constraints/AgentFilter.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/constraints/AgentFilter.scala
@@ -2,8 +2,10 @@ package com.mesosphere.usi.core.models.constraints
 
 import org.apache.mesos.v1.Protos
 
-// Filter on resources or attributes specific to agents.
-// Mostly used for attribute filtering.
+/**
+  * Filter on resources or attributes specific to agents.
+  * Mostly used for attribute filtering.
+  */
 trait AgentFilter {
   def apply(offer: Protos.Offer): Boolean
 

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerFactory.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerFactory.scala
@@ -1,8 +1,8 @@
 package com.mesosphere.usi.core
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.stream.{FanInShape2, Graph}
-import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.{Flow, Sink}
 import com.mesosphere.mesos.client.MesosClient
 import com.mesosphere.usi.core.conf.SchedulerSettings
 import com.mesosphere.usi.core.models.{PodSpecUpdatedEvent, StateEvent, StateSnapshot}
@@ -11,21 +11,32 @@ import com.mesosphere.usi.core.revive.SuppressReviveHandler
 import com.mesosphere.usi.core.util.DurationConverters
 import com.mesosphere.usi.metrics.Metrics
 import com.mesosphere.usi.repository.PodRecordRepository
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.mesos.v1.Protos.FrameworkInfo
 import org.apache.mesos.v1.scheduler.Protos
-import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
-import scala.concurrent.Future
+import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall, Event => MesosEvent}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 private[usi] trait SchedulerLogicFactory {
   private[usi] def newSchedulerLogicGraph(
       snapshot: StateSnapshot): Graph[FanInShape2[SchedulerCommand, MesosEvent, SchedulerEvents], NotUsed]
+
+  val frameworkInfo: FrameworkInfo
 }
 
 private[usi] trait PersistenceFlowFactory {
   private[usi] def newPersistenceFlow(): Flow[SchedulerEvents, SchedulerEvents, NotUsed]
+
+  private[usi] def loadSnapshot(): Future[StateSnapshot]
 }
 
 private[usi] trait SuppressReviveFactory {
   def newSuppressReviveFlow: Flow[PodSpecUpdatedEvent, Protos.Call, NotUsed]
+}
+
+private[usi] trait MesosFlowFactory {
+  def newMesosFlow: Flow[MesosCall, MesosEvent, NotUsed]
 }
 
 /**
@@ -36,19 +47,34 @@ private[usi] trait SuppressReviveFactory {
   * @param schedulerSettings Settings, usually loaded from application.conf
   * @param metrics Metrics
   */
-case class SchedulerFactory(
+class SchedulerFactory private (
     client: MesosClient,
     podRecordRepository: PodRecordRepository,
     schedulerSettings: SchedulerSettings,
-    metrics: Metrics)
+    metrics: Metrics)(implicit ec: ExecutionContext)
     extends SchedulerLogicFactory
     with PersistenceFlowFactory
-    with SuppressReviveFactory {
+    with SuppressReviveFactory
+    with MesosFlowFactory
+    with StrictLogging {
+
+  val frameworkInfo: FrameworkInfo = client.frameworkInfo
+
+  override def newMesosFlow: Flow[MesosCall, MesosEvent, NotUsed] =
+    Flow.fromSinkAndSourceCoupled(logMesosCallException(client.mesosSink), client.mesosSource)
 
   def newSchedulerFlow(): Future[(StateSnapshot, Flow[SchedulerCommand, StateEvent, NotUsed])] =
-    Scheduler.fromClient(this, client, podRecordRepository)
+    Scheduler.asFlow(this)
   override def newPersistenceFlow(): Flow[SchedulerEvents, SchedulerEvents, NotUsed] = {
     Scheduler.newPersistenceFlow(podRecordRepository, schedulerSettings.persistencePipelineLimit)
+  }
+
+  override def loadSnapshot(): Future[StateSnapshot] = {
+    podRecordRepository
+      .readAll()
+      .map { podRecords =>
+        StateSnapshot(podRecords = podRecords.values.toSeq, agentRecords = Nil)
+      }
   }
 
   override def newSchedulerLogicGraph(snapshot: StateSnapshot): SchedulerLogicGraph = {
@@ -64,4 +90,30 @@ case class SchedulerFactory(
       debounceReviveInterval = DurationConverters.toScala(schedulerSettings.debounceReviveInterval)
     ).flow
   }
+
+  private def logMesosCallException[T](s: Sink[T, Future[Done]]): Sink[T, NotUsed] = {
+    s.mapMaterializedValue { f =>
+      f.failed.foreach { ex =>
+        logger.error("Mesos client hanging up due to error in stream", ex)
+      }(CallerThreadExecutionContext.context)
+      NotUsed
+    }
+  }
+}
+
+object SchedulerFactory {
+
+  def apply(
+      client: MesosClient,
+      podRecordRepository: PodRecordRepository,
+      schedulerSettings: SchedulerSettings,
+      metrics: Metrics)(implicit ec: ExecutionContext) =
+    new SchedulerFactory(client, podRecordRepository, schedulerSettings, metrics)
+
+  def create(
+      client: MesosClient,
+      podRecordRepository: PodRecordRepository,
+      schedulerSettings: SchedulerSettings,
+      metrics: Metrics,
+      ec: ExecutionContext) = new SchedulerFactory(client, podRecordRepository, schedulerSettings, metrics)(ec)
 }

--- a/core/src/test/scala/com/mesosphere/usi/core/helpers/MockedFactory.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/helpers/MockedFactory.scala
@@ -7,21 +7,16 @@ import com.mesosphere.usi.core.conf.SchedulerSettings
 import com.mesosphere.usi.core.models.{PodSpecUpdatedEvent, StateSnapshot}
 import com.mesosphere.usi.core.revive.SuppressReviveHandler
 import com.mesosphere.usi.core.util.DurationConverters
-import com.mesosphere.usi.core.{
-  PersistenceFlowFactory,
-  Scheduler,
-  SchedulerEvents,
-  SchedulerLogicFactory,
-  SchedulerLogicGraph,
-  SuppressReviveFactory
-}
+import com.mesosphere.usi.core._
 import com.mesosphere.usi.metrics.Metrics
 import com.mesosphere.usi.repository.PodRecordRepository
 import com.mesosphere.utils.metrics.DummyMetrics
 import com.mesosphere.utils.persistence.InMemoryPodRecordRepository
 import org.apache.mesos.v1.Protos.{DomainInfo, FrameworkID, FrameworkInfo}
+import org.apache.mesos.v1.scheduler.Protos
 import org.apache.mesos.v1.scheduler.Protos.{Call => MesosCall}
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 case class MockedFactory(
@@ -31,14 +26,25 @@ case class MockedFactory(
     frameworkId: FrameworkID = MesosMock.mockFrameworkId,
     frameworkInfo: FrameworkInfo = MesosMock.mockFrameworkInfo(),
     masterDomainInfo: DomainInfo = MesosMock.masterDomainInfo,
-    metrics: Metrics = DummyMetrics)
+    metrics: Metrics = DummyMetrics)(implicit ec: ExecutionContext)
     extends SchedulerLogicFactory
     with PersistenceFlowFactory
-    with SuppressReviveFactory {
+    with SuppressReviveFactory
+    with MesosFlowFactory {
 
   val mesosCalls = new MesosCalls(frameworkId: FrameworkID)
   override def newPersistenceFlow(): Flow[SchedulerEvents, SchedulerEvents, NotUsed] = {
     Scheduler.newPersistenceFlow(podRecordRepository, schedulerSettings.persistencePipelineLimit)
+  }
+
+  override def newMesosFlow: Flow[MesosCall, Protos.Event, NotUsed] = ???
+
+  override def loadSnapshot(): Future[StateSnapshot] = {
+    podRecordRepository
+      .readAll()
+      .map { podRecords =>
+        StateSnapshot(podRecords = podRecords.values.toSeq, agentRecords = Nil)
+      }
   }
 
   override def newSchedulerLogicGraph(snapshot: StateSnapshot): SchedulerLogicGraph = {

--- a/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/integration/SchedulerIntegrationTest.scala
@@ -40,8 +40,7 @@ class SchedulerIntegrationTest extends AkkaUnitTest with MesosClusterTest with I
   val schedulerSettings = SchedulerSettings
     .load()
     .withDebounceReviveInterval(DurationConverters.toJava(50.millis))
-  lazy val factory =
-    new SchedulerFactory(mesosClient, InMemoryPodRecordRepository(), schedulerSettings, DummyMetrics)
+  lazy val factory = SchedulerFactory(mesosClient, InMemoryPodRecordRepository(), schedulerSettings, DummyMetrics)
   lazy val (snapshot, schedulerFlow) =
     factory.newSchedulerFlow().futureValue
   lazy val (input, output) = commandInputSource


### PR DESCRIPTION
Summary:
The scheduelr factory already has a Mesos client and repository. Thus
the constructors `asFlow` and `asSourceAndSink` should not require these
as parameters.