### PR TITLE
Fail Mesos client if master version is too old.

### DIFF
--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -14,7 +14,7 @@ import akka.stream.{Materializer, OverflowStrategy, _}
 import akka.util.{ByteString, Timeout}
 import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
-import com.mesosphere.mesos.conf.MesosClientSettings
+import com.mesosphere.mesos.conf.{MesosClientSettings, SemanticVersion}
 import org.apache.mesos.v1.Protos.{FrameworkID, FrameworkInfo, MasterInfo}
 import org.apache.mesos.v1.scheduler.Protos.{Call, Event}
 
@@ -396,6 +396,12 @@ class MesosClientImpl(
   val calls = new MesosCalls(frameworkId)
 
   val masterInfo = subscribed.getMasterInfo
+
+  val minimalVersion = SemanticVersion(1, 9, 0)
+  val version = SemanticVersion(masterInfo.getVersion).get
+  require(
+    version >= minimalVersion,
+    s"Mesos master version $version is not compatible with required version $minimalVersion.")
 
   override def killSwitch: KillSwitch = sharedKillSwitch
 

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/conf/SemanticVersion.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/conf/SemanticVersion.scala
@@ -1,0 +1,29 @@
+package com.mesosphere.mesos.conf
+
+import scala.util.matching.Regex
+
+case class SemanticVersion(major: Int, minor: Int, patch: Int) {
+
+  override val toString: String = s"$major.$minor.$patch"
+}
+
+object SemanticVersion {
+  val Pattern: Regex = """(\d+)\.(\d+)\.(\d+).*""".r
+
+  val zero = SemanticVersion(0, 0, 0)
+
+  // If we can not match the version pattern we prefer to throw an
+  // error rather than silently construct a dummy version.
+  def apply(version: String): Option[SemanticVersion] = version match {
+    case Pattern(major, minor, patch) =>
+      Some(new SemanticVersion(major.toInt, minor.toInt, patch.toInt))
+    case _ => None
+  }
+
+  implicit class OrderedSemanticVersion(val version: SemanticVersion) extends AnyVal with Ordered[SemanticVersion] {
+    override def compare(that: SemanticVersion): Int = {
+      def by(left: Int, right: Int, fn: => Int): Int = if (left.compareTo(right) != 0) left.compareTo(right) else fn
+      by(version.major, that.major, by(version.minor, that.minor, by(version.patch, that.patch, 0)))
+    }
+  }
+}

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
@@ -1,0 +1,42 @@
+package com.mesosphere.mesos.client
+import java.net.URL
+
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Source
+import akka.util.Timeout
+import com.mesosphere.utils.AkkaUnitTest
+import org.apache.mesos.v1.Protos.{FrameworkID, MasterInfo}
+import org.apache.mesos.v1.scheduler.Protos.Event
+
+import scala.concurrent.duration._
+
+class MesosClientImplTest extends AkkaUnitTest {
+
+  implicit val askTimeout = Timeout(1.minute)
+
+  "Mesos client" should {
+    "fail if the provided Mesos version is incompatible" in {
+      val masterInfo = MasterInfo.newBuilder().setVersion("1.8.0").setId("unique").setIp(42).setPort(0).build()
+      val frameworkId = FrameworkID.newBuilder().setValue("framework").build()
+      val subscribedEvent = Event.Subscribed.newBuilder().setMasterInfo(masterInfo).setFrameworkId(frameworkId).build()
+      val sharedKillSwitch = KillSwitches.shared("mesos-client-killswitch")
+      val session = Session(new URL("http://localhost"), "stream-id")
+
+      a[IllegalArgumentException] should be thrownBy {
+        new MesosClientImpl(null, sharedKillSwitch, subscribedEvent, session, Source.empty)
+      }
+    }
+
+    "pass if the provided Mesos version is compatible" in {
+      val masterInfo = MasterInfo.newBuilder().setVersion("1.9.0").setId("unique").setIp(42).setPort(0).build()
+      val frameworkId = FrameworkID.newBuilder().setValue("framework").build()
+      val subscribedEvent = Event.Subscribed.newBuilder().setMasterInfo(masterInfo).setFrameworkId(frameworkId).build()
+      val sharedKillSwitch = KillSwitches.shared("mesos-client-killswitch")
+      val session = new Session(new URL("http://localhost"), "stream-id")
+
+      noException should be thrownBy {
+        new MesosClientImpl(null, sharedKillSwitch, subscribedEvent, session, Source.empty)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
The Jenkins plugin reported `HTTP 400` errors. To ensure that the Mesos
master version is compatible we are checking it during the client
creation.