### PR TITLE
Explain why domain filter declined offer.

### DIFF
--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/AnyDomain.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/AnyDomain.scala
@@ -4,4 +4,6 @@ import org.apache.mesos.v1.Protos
 object AnyDomain extends DomainFilter {
 
   override def apply(masterDomain: Protos.DomainInfo, nodeDomain: Protos.DomainInfo): Boolean = true
+
+  override def description: String = "accept any domain"
 }

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/DomainFilter.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/DomainFilter.scala
@@ -8,4 +8,7 @@ import org.apache.mesos.v1.Protos.DomainInfo
   */
 trait DomainFilter {
   def apply(masterDomain: DomainInfo, nodeDomain: DomainInfo): Boolean
+
+  /** @return a text description of the matcher */
+  def description: String
 }

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/HomeRegionFilter.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/HomeRegionFilter.scala
@@ -5,4 +5,6 @@ case object HomeRegionFilter extends DomainFilter {
   override def apply(masterDomain: DomainInfo, nodeDomain: DomainInfo): Boolean = {
     masterDomain.getFaultDomain.getRegion == nodeDomain.getFaultDomain.getRegion
   }
+
+  override def description: String = "expect home region."
 }

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/RegionFilter.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/faultdomain/RegionFilter.scala
@@ -5,4 +5,6 @@ case class RegionFilter(region: String) extends DomainFilter {
   override def apply(masterDomain: Protos.DomainInfo, nodeDomain: Protos.DomainInfo): Boolean = {
     region == nodeDomain.getFaultDomain.getRegion.getName
   }
+
+  override def description: String = s"expect region $region"
 }

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -5,6 +5,7 @@ import com.mesosphere.usi.core.logic.{MesosEventsLogic, SpecLogic}
 import com.mesosphere.usi.core.models.commands.SchedulerCommand
 import com.mesosphere.usi.core.models.{PodId, PodSpecUpdatedEvent, PodStatusUpdatedEvent, StateSnapshot}
 import com.mesosphere.usi.metrics.Metrics
+import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.Protos.DomainInfo
 import org.apache.mesos.v1.scheduler.Protos.{Event => MesosEvent}
 
@@ -69,7 +70,7 @@ private[core] class SchedulerLogicHandler(
     mesosCallFactory: MesosCalls,
     masterDomainInfo: DomainInfo,
     initialState: StateSnapshot,
-    metrics: Metrics) {
+    metrics: Metrics) extends StrictLogging {
 
   private val schedulerLogic = new SpecLogic(mesosCallFactory)
   private val mesosEventsLogic = new MesosEventsLogic(mesosCallFactory, masterDomainInfo, metrics)
@@ -104,6 +105,7 @@ private[core] class SchedulerLogicHandler(
 
     // update our state for the next frame processing
     this.state = frameResultBuilder.state
+    logger.debug(s"Scheduler state after frame handling: ${this.state.summary()}")
 
     // Return our result
     frameResultBuilder.result

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerLogicHandler.scala
@@ -70,7 +70,8 @@ private[core] class SchedulerLogicHandler(
     mesosCallFactory: MesosCalls,
     masterDomainInfo: DomainInfo,
     initialState: StateSnapshot,
-    metrics: Metrics) extends StrictLogging {
+    metrics: Metrics)
+    extends StrictLogging {
 
   private val schedulerLogic = new SpecLogic(mesosCallFactory)
   private val mesosEventsLogic = new MesosEventsLogic(mesosCallFactory, masterDomainInfo, metrics)

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
@@ -56,6 +56,10 @@ case class SchedulerState(
     copy(podRecords = newPodRecords, podStatuses = newPodStatuses, podSpecs = newPodSpecs)
   }
 
+  /** @return a summary for debug logs. */
+  def summary(): String = {
+    s"${podRecords.size} records, ${podStatuses} statuses, ${podSpecs} specs"
+  }
 }
 
 object SchedulerState {

--- a/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/SchedulerState.scala
@@ -58,7 +58,7 @@ case class SchedulerState(
 
   /** @return a summary for debug logs. */
   def summary(): String = {
-    s"${podRecords.size} records, ${podStatuses} statuses, ${podSpecs} specs"
+    s"${podRecords.size} records, ${podStatuses.size} statuses, ${podSpecs.size} specs"
   }
 }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/logic/MesosEventsLogic.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/logic/MesosEventsLogic.scala
@@ -113,6 +113,9 @@ private[core] class MesosEventsLogic(mesosCallFactory: MesosCalls, masterDomainI
         val (schedulerEventsBuilder, _) =
           offersList.asScala.foldLeft((SchedulerEventsBuilder.empty, pendingLaunchPodSpecs)) {
             case ((builder, pending), offer) =>
+              logger.debug(s"Processing offer ${offer.getId.getValue} from agent ${offer.getAgentId.getValue}")(
+                LoggingArgs("offerId" -> offer.getId.getValue).and("agentId" -> offer.getAgentId.getValue)
+              )
               metrics.timer("usi.scheduler.offer.processing").blocking {
 
                 val (matchedPodIds, offerMatchSchedulerEvents) = matchOffer(

--- a/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.usi.core.logic
 
-import com.mesosphere.LoggingArgs
+import com.mesosphere.{ImplicitStrictLogging, LoggingArgs}
 import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core._
 import com.mesosphere.usi.core.models._
@@ -11,7 +11,7 @@ import com.typesafe.scalalogging.StrictLogging
   * The current home for USI business logic for dealing with spec commands
   *
   */
-private[core] class SpecLogic(mesosCallFactory: MesosCalls) extends StrictLogging {
+private[core] class SpecLogic(mesosCallFactory: MesosCalls) extends StrictLogging with ImplicitStrictLogging {
 
   private def getRunningPodSpec(podSpecs: Map[PodId, PodSpec], id: PodId): Option[RunningPodSpec] = {
     podSpecs.get(id).collect { case r: RunningPodSpec => r }

--- a/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
@@ -1,15 +1,17 @@
 package com.mesosphere.usi.core.logic
 
+import com.mesosphere.LoggingArgs
 import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core._
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.commands.{CreateReservation, ExpungePod, KillPod, LaunchPod, SchedulerCommand}
+import com.typesafe.scalalogging.StrictLogging
 
 /**
   * The current home for USI business logic for dealing with spec commands
   *
   */
-private[core] class SpecLogic(mesosCallFactory: MesosCalls) {
+private[core] class SpecLogic(mesosCallFactory: MesosCalls) extends StrictLogging {
 
   private def getRunningPodSpec(podSpecs: Map[PodId, PodSpec], id: PodId): Option[RunningPodSpec] = {
     podSpecs.get(id).collect { case r: RunningPodSpec => r }
@@ -17,9 +19,15 @@ private[core] class SpecLogic(mesosCallFactory: MesosCalls) {
   private[core] def handleCommand(state: SchedulerState)(command: SchedulerCommand): SchedulerEvents = {
     command match {
       case launchPod: LaunchPod =>
+        logger.debug(s"Received launch for pod ${launchPod.podId}")(
+          LoggingArgs("podId" -> launchPod.podId)
+        )
         if (state.podRecords.contains(launchPod.podId) || getRunningPodSpec(state.podSpecs, launchPod.podId)
             .exists(_.runSpec == launchPod.runSpec)) {
           // if we already have a record for the pod, ignore
+          logger.debug(s"Pod ${launchPod.podId} already exists.")(
+            LoggingArgs("podId" -> launchPod.podId)
+          )
           SchedulerEvents.empty
         } else {
           SchedulerEvents(
@@ -28,6 +36,9 @@ private[core] class SpecLogic(mesosCallFactory: MesosCalls) {
               Some(RunningPodSpec(launchPod.podId, launchPod.runSpec, launchPod.domainFilter, launchPod.agentFilter)))))
         }
       case ExpungePod(podId) =>
+        logger.debug(s"Received expunge for pod $podId")(
+          LoggingArgs("podId" -> podId)
+        )
         var b = SchedulerEventsBuilder.empty
         if (state.podSpecs.contains(podId)) {
           b = b.withStateEvent(PodSpecUpdatedEvent(podId, None))
@@ -37,6 +48,9 @@ private[core] class SpecLogic(mesosCallFactory: MesosCalls) {
         }
         b.result
       case KillPod(podId) =>
+        logger.debug(s"Received kill for pod $podId")(
+          LoggingArgs("podId" -> podId)
+        )
         var b = SchedulerEventsBuilder.empty.withStateEvent(PodSpecUpdatedEvent(podId, Some(TerminalPodSpec(podId))))
 
         state.podStatuses.get(podId).foreach { status =>

--- a/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/logic/SpecLogic.scala
@@ -5,13 +5,12 @@ import com.mesosphere.mesos.client.MesosCalls
 import com.mesosphere.usi.core._
 import com.mesosphere.usi.core.models._
 import com.mesosphere.usi.core.models.commands.{CreateReservation, ExpungePod, KillPod, LaunchPod, SchedulerCommand}
-import com.typesafe.scalalogging.StrictLogging
 
 /**
   * The current home for USI business logic for dealing with spec commands
   *
   */
-private[core] class SpecLogic(mesosCallFactory: MesosCalls) extends StrictLogging with ImplicitStrictLogging {
+private[core] class SpecLogic(mesosCallFactory: MesosCalls) extends ImplicitStrictLogging {
 
   private def getRunningPodSpec(podSpecs: Map[PodId, PodSpec], id: PodId): Option[RunningPodSpec] = {
     podSpecs.get(id).collect { case r: RunningPodSpec => r }

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.usi.core.matching
 
-import com.mesosphere.ImplicitStrictLogging
+import com.mesosphere.{ImplicitStrictLogging, LoggingArgs}
 import com.mesosphere.usi.core.models.constraints.AgentFilter
 import com.mesosphere.usi.core.models.faultdomain.DomainFilter
 import com.mesosphere.usi.core.models.template.RunTemplate.KeyedResourceRequirement

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
@@ -58,7 +58,9 @@ class OfferMatcher(masterDomainInfo: Mesos.DomainInfo) extends StrictLogging {
       val result = domainFilter(masterDomainInfo, originalOffer.getDomain)
       if (!result)
         logger.debug(
-          s"Declining offer ${originalOffer.getId.getValue} for pod $podId; domain filter: ${domainFilter.description}.")
+          s"Declining offer ${originalOffer.getId.getValue} for pod $podId; domain filter did not match: ${domainFilter.description}.")(
+            LoggingArgs("podId" -> podId)
+          )
       result
     }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
@@ -1,16 +1,17 @@
 package com.mesosphere.usi.core.matching
+
+import com.mesosphere.ImplicitStrictLogging
 import com.mesosphere.usi.core.models.constraints.AgentFilter
 import com.mesosphere.usi.core.models.faultdomain.DomainFilter
 import com.mesosphere.usi.core.models.template.RunTemplate.KeyedResourceRequirement
 import com.mesosphere.usi.core.models.resources.ResourceType
 import com.mesosphere.usi.core.models.{PodId, RunningPodSpec, TaskName}
-import com.typesafe.scalalogging.StrictLogging
 import org.apache.mesos.v1.{Protos => Mesos}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-class OfferMatcher(masterDomainInfo: Mesos.DomainInfo) extends StrictLogging {
+class OfferMatcher(masterDomainInfo: Mesos.DomainInfo) extends ImplicitStrictLogging {
   @tailrec private def maybeMatchResourceRequirements(
       remainingResources: Map[ResourceType, Seq[Mesos.Resource]],
       matchedResources: List[OfferMatcher.ResourceMatch],

--- a/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/matching/OfferMatcher.scala
@@ -59,8 +59,8 @@ class OfferMatcher(masterDomainInfo: Mesos.DomainInfo) extends StrictLogging {
       if (!result)
         logger.debug(
           s"Declining offer ${originalOffer.getId.getValue} for pod $podId; domain filter did not match: ${domainFilter.description}.")(
-            LoggingArgs("podId" -> podId)
-          )
+          LoggingArgs("podId" -> podId)
+        )
       result
     }
 

--- a/core/src/main/scala/com/mesosphere/usi/core/revive/SuppressReviveHandler.scala
+++ b/core/src/main/scala/com/mesosphere/usi/core/revive/SuppressReviveHandler.scala
@@ -132,6 +132,8 @@ private[core] class SuppressReviveHandler(
   private[revive] val reviveSuppressMetrics: Flow[RoleDirective, RoleDirective, NotUsed] =
     Flow[RoleDirective].map {
       case directive @ IssueUpdateFramework(_, newlyRevived, newlySuppressed) =>
+        logger.debug(
+          s"Newly suppress roles ${newlySuppressed.mkString(", ")}, newly revived roles ${newlyRevived.mkString(", ")}")
         newlyRevived.foreach { _ =>
           reviveCountMetric.increment()
         }
@@ -141,6 +143,7 @@ private[core] class SuppressReviveHandler(
         directive
 
       case directive @ IssueRevive(roles) =>
+        logger.debug(s"Reviving ${roles.mkString(", ")}")
         roles.foreach { _ =>
           reviveCountMetric.increment()
         }


### PR DESCRIPTION
Summary:
The domain filter would not give a reason why an offer was rejected.
This change introduces a similar log line to the agent filter.