### PR TITLE
Add helps to make it more easy to find an agent process's agentId

### DIFF
--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFacade.scala
@@ -106,6 +106,15 @@ object MesosFacade {
       frameworks: Seq[ITFramework],
       completed_frameworks: Seq[ITFramework],
       unregistered_frameworks: Seq[ITFramework])
+
+  case class ITFaultDomain(region: String, Zone: String)
+  case class ITAgentDetails(
+      id: String,
+      pid: String,
+      hostname: String,
+      capabilities: Seq[String],
+      domain: Option[ITFaultDomain],
+      flags: Map[String, String])
 }
 
 class MesosFacade(val url: URL, val waitTime: FiniteDuration = 30.seconds)(
@@ -131,6 +140,10 @@ class MesosFacade(val url: URL, val waitTime: FiniteDuration = 30.seconds)(
 
   def agents(): RestResult[ITAgents] = {
     result(requestFor[ITAgents](Get(s"$url/slaves")), waitTime)
+  }
+
+  def agentDetails(agent: MesosTest.AgentLike): RestResult[ITAgentDetails] = {
+    result(requestFor[ITAgentDetails](Get(s"http://${agent.ip}:${agent.port}/state")), waitTime)
   }
 
   def frameworkIds(): RestResult[Seq[String]] = {

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFormats.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosFormats.scala
@@ -68,4 +68,11 @@ object MesosFormats {
   implicit lazy val ITFrameworksFormat: Format[ITFrameworks] = Json.format[ITFrameworks]
 
   implicit lazy val ITAgentsFormat: Format[ITAgents] = Json.format[ITAgents]
+
+  implicit val ITFaultDomainFormat: Format[ITFaultDomain] = (
+    (__ \ "fault_domain" \ "region" \ "name").format[String] ~
+      (__ \ "fault_domain" \ "zone" \ "name").format[String]
+  )(ITFaultDomain.apply, unlift(ITFaultDomain.unapply))
+
+  implicit val ITAgentDetailsFormat: Format[ITAgentDetails] = Json.format[ITAgentDetails]
 }

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -489,7 +489,7 @@ trait MesosClusterTest
     // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
     mesosCluster.agents.foreach(_.start())
     eventually {
-      val state = mesosFacade.state.value
+      val state = mesosFacade.state().value
       state.agents.size shouldBe mesosCluster.agents.size
       forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
     }

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -486,14 +486,6 @@ trait MesosClusterTest
   }
 
   abstract override def afterAll(): Unit = {
-    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
-    mesosCluster.agents.foreach(_.start())
-    eventually {
-      val state = mesosFacade.state().value
-      forAll(state.agents) { _.active should be(true)}
-      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
-    }
-
     mesosCluster.close()
     super.afterAll()
   }

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -15,7 +15,6 @@ import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, Suite}
-import org.scalatest.Inspectors.forAll
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -220,9 +220,20 @@ case class MesosCluster(
     }.toMap
   }
 
-  def agentIdFor(a: AgentLike): String = {
-    initialCachedAgentDetails(a).id
+  /** Returns a agent id for an agent as it was initially queried during test cluster launch
+    *
+    * @param agent
+    */
+  def agentIdFor(agent: AgentLike): String = {
+    initialCachedAgentDetails(agent).id
   }
+
+  /**
+    * Return the cached agent details that were returned when the agent first initialized
+    * @param agent Reference to the MesosTest Agent process
+    */
+  def initialAgentDetailsFor(agent: AgentLike): ITAgentDetails =
+    initialCachedAgentDetails(agent)
 
   // format: OFF
   case class Resources(cpus: Option[Int] = None, mem: Option[Int] = None, ports: (Int, Int), gpus: Option[Int] = None) {

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -490,7 +490,7 @@ trait MesosClusterTest
     mesosCluster.agents.foreach(_.start())
     eventually {
       val state = mesosFacade.state().value
-      state.agents.size shouldBe mesosCluster.agents.size
+      forAll(state.agents) { _.active should be(true)}
       forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
     }
 

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -485,14 +485,6 @@ trait MesosClusterTest
   }
 
   abstract override def afterAll(): Unit = {
-    mesosCluster.agents.filterNot(_.isAlive()).foreach(_.start())
-    withClue("In order for teardown to complete successfully, all agents must be active") {
-      eventually {
-        val inactiveAgents = mesosFacade.agents().value.slaves.filterNot(_.active)
-        inactiveAgents shouldBe (Nil)
-      }
-    }
-
     mesosCluster.close()
     super.afterAll()
   }


### PR DESCRIPTION
We add helper methods to get the id for a given agent by caching the agent details response during the start of the cluster.

Finally, we resolve a bug in which waitForAgents did not actually wait for agents (a simple comparison was done rather than an assertion in the eventually clause).