### PR TITLE
Require that principal is set for authz.

### DIFF
--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -341,6 +341,10 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
       system: ActorSystem,
       materializer: Materializer): Source[MesosClient, NotUsed] = {
 
+    if(authorization.nonEmpty) {
+      require(frameworkInfo.hasPrincipal, "The framework info must have a principal set if authorization is used.")
+    }
+
     implicit val askTimeout = Timeout(conf.callTimeout)
     val httpConnection: Source[(HttpResponse, Session), NotUsed] =
       mesosHttpConnection(frameworkInfo, conf, authorization)

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -341,7 +341,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
       system: ActorSystem,
       materializer: Materializer): Source[MesosClient, NotUsed] = {
 
-    if(authorization.nonEmpty) {
+    if (authorization.nonEmpty) {
       require(frameworkInfo.hasPrincipal, "The framework info must have a principal set if authorization is used.")
     }
 


### PR DESCRIPTION
Summary:
This should ease some usage. The principal must be set in the framework
info when authorization is used. `UPDATE_FRAMEWORK` calls might fails
otherwise.