### PR TITLE
Enable user to use Docker entrypoint.

### DIFF
--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/template/SimpleRunTemplateFactory.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/template/SimpleRunTemplateFactory.scala
@@ -1,9 +1,12 @@
 package com.mesosphere.usi.core.models.template
 
+import java.util.Optional
+
 import com.mesosphere.usi.core.models.resources.ResourceRequirement
-import com.mesosphere.usi.core.models.{TaskName, TaskBuilder}
+import com.mesosphere.usi.core.models.{TaskBuilder, TaskName}
 import org.apache.mesos.v1.{Protos => Mesos}
 
+import scala.annotation.varargs
 import scala.collection.JavaConverters._
 
 object SimpleRunTemplateFactory {
@@ -50,10 +53,8 @@ object SimpleRunTemplateFactory {
     def apply(args: Seq[String]) = new DockerEntrypoint(args)
 
     /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint]]; Java Api. */
-    def create(args: java.util.List[String]) = new DockerEntrypoint(args.asScala)
-
-    /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint]]; Java Api. */
-    def create(arg: String) = new DockerEntrypoint(Seq(arg))
+    @varargs
+    def create(args: String*) = new DockerEntrypoint(args)
   }
 
   /**
@@ -133,13 +134,16 @@ object SimpleRunTemplateFactory {
         dockerImageName: Option[String] = None): SimpleTaskInfoBuilder =
       apply(resourceRequirements, Shell(shellCommand), role, fetch, dockerImageName)
 
+    /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.SimpleTaskInfoBuilder]]; Java Api. */
     def create(
         resourceRequirements: java.util.List[ResourceRequirement],
         command: Command,
         role: String,
         fetch: java.util.List[FetchUri],
-        dockerImageName: Option[String]): SimpleTaskInfoBuilder =
-      apply(resourceRequirements.asScala, command, role, fetch.asScala, dockerImageName)
+        dockerImageName: Optional[String]): SimpleTaskInfoBuilder = {
+      val image = if (dockerImageName.isPresent) Some(dockerImageName.get()) else None
+      apply(resourceRequirements.asScala, command, role, fetch.asScala, image)
+    }
   }
 
   /**

--- a/core-models/src/main/scala/com/mesosphere/usi/core/models/template/SimpleRunTemplateFactory.scala
+++ b/core-models/src/main/scala/com/mesosphere/usi/core/models/template/SimpleRunTemplateFactory.scala
@@ -32,7 +32,7 @@ object SimpleRunTemplateFactory {
     *
     * @param args A list of arguments passed.
     */
-  case class DockerEntrypoint(args: List[String]) extends Command {
+  class DockerEntrypoint private (args: Seq[String]) extends Command {
     def build(): Mesos.CommandInfo.Builder = {
       val builder = Mesos.CommandInfo
         .newBuilder()
@@ -42,6 +42,18 @@ object SimpleRunTemplateFactory {
 
       builder
     }
+  }
+
+  object DockerEntrypoint {
+
+    /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint]]; Scala Api. */
+    def apply(args: Seq[String]) = new DockerEntrypoint(args)
+
+    /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint]]; Java Api. */
+    def create(args: java.util.List[String]) = new DockerEntrypoint(args.asScala)
+
+    /** Factory method for [[com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint]]; Java Api. */
+    def create(arg: String) = new DockerEntrypoint(Seq(arg))
   }
 
   /**
@@ -123,11 +135,11 @@ object SimpleRunTemplateFactory {
 
     def create(
         resourceRequirements: java.util.List[ResourceRequirement],
-        shellCommand: String,
+        command: Command,
         role: String,
         fetch: java.util.List[FetchUri],
         dockerImageName: Option[String]): SimpleTaskInfoBuilder =
-      apply(resourceRequirements.asScala, Shell(shellCommand), role, fetch.asScala, dockerImageName)
+      apply(resourceRequirements.asScala, command, role, fetch.asScala, dockerImageName)
   }
 
   /**


### PR DESCRIPTION
Summary:
This enables USI users to sepcify whether a command is executed in shell
or passed as an argument to the entrypoint of a Docker image.

Relates to https://github.com/mesosphere/dcos-jenkins-service/pull/319.

JIRA issues: DCOS_OSS-5937