### PR TITLE
Fix flaky FlowHelpersTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ git:
   depth: false
 script:
 - sudo ci/provision.sh 1.9.0
-- ci/reporting-pr-failure -- sbt +test:compile
-- ci/reporting-pr-failure -- sbt scalafmtCheck
-- ci/reporting-pr-failure --description "Unused imports / scalafix" -- sbt "scalafix --check"
-- ci/reporting-pr-failure --description "Running tests for all Scala versions" -- sbt +test
+- ci/reporting-pr-failure -- sbt "+test:compile"
+- ci/reporting-pr-failure -- sbt "scalafmtCheck" "test:scalafmtCheck"
+- ci/reporting-pr-failure --description "Unused imports / scalafix" -- sbt "scalafix --check" "test:scalafix --check"
+- ci/reporting-pr-failure --description "Running tests for all Scala versions" -- sbt "+test"

--- a/core/src/test/scala/com/mesosphere/usi/core/FlowHelpersTest.scala
+++ b/core/src/test/scala/com/mesosphere/usi/core/FlowHelpersTest.scala
@@ -1,13 +1,8 @@
 package com.mesosphere.usi.core
 
-import java.util.UUID
-
-import akka.stream.KillSwitches
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.{Done, NotUsed}
 import com.mesosphere.utils.AkkaUnitTest
-
-import scala.util.{Failure, Success}
 
 class FlowHelpersTest extends AkkaUnitTest {
   val inputElement = "one"


### PR DESCRIPTION
The test helper method fromSinkAndSourceWithSharedFate had a race in it.
New Akka streams provides an equivalent method without bugs so we use it
instead.