### PR TITLE
Fix redirect in Mesos client.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 
       environment {
         AWS_ACCESS_KEY_ID = credentials('3f0dbb48-de33-431f-b91c-2366d2f0e1cf')
-        AWS_SECRET_ACCESS_KEY = credentials('f585ec9a-3c38-4f67-8bdb-79e5d4761937')
+        AWS_SECRET_KEY = credentials('f585ec9a-3c38-4f67-8bdb-79e5d4761937')
       }
 
       steps {

--- a/build.sbt
+++ b/build.sbt
@@ -25,11 +25,11 @@ val commonSettings = Seq(
     if (version.value.endsWith("-SNAPSHOT"))
       Some(s3resolver.value(
         "Mesosphere Public Snapshot Repo (S3)",
-        s3("downloads.mesosphere.io/maven-snapshot")))
+        s3("downloads.mesosphere.io/maven-snapshot")).withMavenPatterns)
     else
       Some(s3resolver.value(
         "Mesosphere Public Repo (S3)",
-        s3("downloads.mesosphere.io/maven")))
+        s3("downloads.mesosphere.io/maven")).withMavenPatterns)
   },
   s3credentials := DefaultAWSCredentialsProviderChain.getInstance(),
   s3region :=  com.amazonaws.services.s3.model.Region.US_Standard,

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+//import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.typesafe.sbt.SbtGit.GitKeys._
 
 val commonSettings = Seq(
@@ -23,17 +23,11 @@ val commonSettings = Seq(
   ),
   publishTo := {
     if (version.value.endsWith("-SNAPSHOT"))
-      Some(s3resolver.value(
-        "Mesosphere Public Snapshot Repo (S3)",
-        s3("downloads.mesosphere.io/maven-snapshot")).withMavenPatterns)
+      Some("Mesosphere Public Snapshot Repo (S3)" at "s3://downloads.mesosphere.io/maven-snapshots")
     else
-      Some(s3resolver.value(
-        "Mesosphere Public Repo (S3)",
-        s3("downloads.mesosphere.io/maven")).withMavenPatterns)
+      Some("Mesosphere Public Snapshot Repo (S3)" at "s3://downloads.mesosphere.io/maven")
   },
-  publishMavenStyle := true,
-  s3credentials := DefaultAWSCredentialsProviderChain.getInstance(),
-  s3region :=  com.amazonaws.services.s3.model.Region.US_Standard,
+  publishMavenStyle := true
 )
 
 lazy val docs = (project in file("./docs"))
@@ -45,8 +39,6 @@ lazy val docs = (project in file("./docs"))
       ("./version" !!).trim
     },
 
-    s3credentials := DefaultAWSCredentialsProviderChain.getInstance(),
-    s3region :=  com.amazonaws.services.s3.model.Region.US_Standard,
     publish / skip := true,
 
     name := "USI - Unified Scheduler Interface",

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ val commonSettings = Seq(
         "Mesosphere Public Repo (S3)",
         s3("downloads.mesosphere.io/maven")).withMavenPatterns)
   },
+  publishMavenStyle := true,
   s3credentials := DefaultAWSCredentialsProviderChain.getInstance(),
   s3region :=  com.amazonaws.services.s3.model.Region.US_Standard,
 )

--- a/examples/simple-hello-world/src/main/scala/com/mesosphere/mesos/examples/SimpleHelloWorldFramework.scala
+++ b/examples/simple-hello-world/src/main/scala/com/mesosphere/mesos/examples/SimpleHelloWorldFramework.scala
@@ -38,7 +38,7 @@ class SimpleHelloWorldFramework(settings: MesosClientSettings) extends StrictLog
 
   logger.info(s"""Successfully subscribed to Mesos:
                  | Framework Id: ${client.frameworkId.getValue}
-                 | Mesos host: ${client.session.url}
+                 | Mesos host: ${client.session.baseUri}
        """.stripMargin)
 
   /**

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -224,7 +224,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
               val protocol = url.getProtocol
               // TODO: what happens when we redirect from http to https?
               val redirect = response.header[headers.Location].get.value()
-              val redirectUrl = s"$protocol$redirect"
+              val redirectUrl = s"$protocol:$redirect"
               logger.warn(s"New Mesos leader available at $redirectUrl")
               val leader = new URL(redirectUrl)
               // Update the context with the new leader's host and port and throw an exception that is handled in the

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -197,6 +197,10 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
             val redirectUri = locationHeader.uri.resolvedAgainst(uri)
             logger.warn(s"Redirect Mesos client from $uri to $redirectUri given header '$locationHeader'")
             response.discardEntityBytes()
+
+            if (redirectUri == uri) {
+              throw new IOException(s"Failed to connect to Mesos: Circular redirection for $uri.")
+            }
             connectionSource(frameworkInfo, redirectUri, authorization, redirectsLeft - 1)
           } else {
             throw new IOException("Failed to connect to Mesos: Too many redirects.")

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -253,7 +253,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
           }
         }.recoverWithRetries(
           1, {
-            case ex =>
+            case ex if rest.nonEmpty =>
               // TODO: This retry only works on the initial connection. It does *not* work the the connection dies.
               logger.warn(s"Failed to connect to Mesos $baseUri", ex)
               mesosHttpConnection(frameworkInfo, rest, maxRedirects, authorization)

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -221,9 +221,12 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
 
               (response, Session(url, streamId.value(), authorization))
             case StatusCodes.TemporaryRedirect =>
+              val protocol = url.getProtocol
+              // TODO: what happens when we redirect from http to https?
               val redirect = response.header[headers.Location].get.value()
-              logger.warn(s"New Mesos leader available at $redirect")
-              val leader = new URL(redirect)
+              val redirectUrl = s"$protocol$redirect"
+              logger.warn(s"New Mesos leader available at $redirectUrl")
+              val leader = new URL(redirectUrl)
               // Update the context with the new leader's host and port and throw an exception that is handled in the
               // next `recoverWith` stage.
               response.discardEntityBytes()

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -249,6 +249,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
         }.recoverWithRetries(
           1, {
             case ex =>
+              // TODO: This retry only works on the initial connection. It does *not* work the the connection dies.
               logger.warn(s"Failed to connect to Mesos $baseUri", ex)
               mesosHttpConnection(frameworkInfo, rest, maxRedirects, authorization)
           }

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -188,13 +188,14 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
     }
 
     requestSource
-      .via(info(s"Connecting to the new leader: $uri"))
+      .via(info(s"Connecting to the new leader: $uri "))
       .via(httpConnection)
       .flatMapConcat { response: HttpResponse =>
         if (response.status.isRedirection()) {
           if (redirectsLeft > 0) {
-            val redirectUri = response.header[headers.Location].get.uri.resolvedAgainst(uri)
-            logger.warn(s"Redirect Mesos client from $uri to $redirectUri")
+            val locationHeader = response.header[headers.Location].get
+            val redirectUri = locationHeader.uri.resolvedAgainst(uri)
+            logger.warn(s"Redirect Mesos client from $uri to $redirectUri given header '$locationHeader'")
             response.discardEntityBytes()
             connectionSource(frameworkInfo, redirectUri, authorization, redirectsLeft - 1)
           } else {

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -221,8 +221,9 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
 
               (response, Session(url, streamId.value(), authorization))
             case StatusCodes.TemporaryRedirect =>
-              val leader = new URL(response.header[headers.Location].get.value())
-              logger.warn(s"New Mesos leader available at $leader")
+              val redirect = response.header[headers.Location].get.value()
+              logger.warn(s"New Mesos leader available at $redirect")
+              val leader = new URL(redirect)
               // Update the context with the new leader's host and port and throw an exception that is handled in the
               // next `recoverWith` stage.
               response.discardEntityBytes()

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/MesosClient.scala
@@ -236,7 +236,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
         connectionSource(frameworkInfo, requestUri, authorization, maxRedirects).map { response =>
           response.status match {
             case StatusCodes.OK =>
-              logger.info(s"Connected successfully to $baseUrl");
+              logger.info(s"Connected successfully to $baseUri");
               val streamId = response.headers
                 .find(h => h.is(MesosStreamIdHeaderName.toLowerCase))
                 .getOrElse(throw new IllegalStateException(s"Missing MesosStreamId header in ${response.headers}"))
@@ -249,7 +249,7 @@ object MesosClient extends StrictLogging with StrictLoggingFlow {
         }.recoverWithRetries(
           1, {
             case ex =>
-              logger.warn(s"Failed to connect to Mesos $baseUrl", ex)
+              logger.warn(s"Failed to connect to Mesos $baseUri", ex)
               mesosHttpConnection(frameworkInfo, rest, maxRedirects, authorization)
           }
         )

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
@@ -1,5 +1,4 @@
 package com.mesosphere.mesos.client
-import java.net.URL
 
 import akka.NotUsed
 import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash, Status}

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
@@ -115,17 +115,14 @@ case class Session(url: URL, streamId: String, authorization: Option[Credentials
 object Session {
 
   /** @return whether the url defines a secured connection. */
-  def isSecured(url: URL): Boolean = {
-    url.getProtocol match {
+  def isSecured(uri: Uri): Boolean = {
+    uri.scheme match {
       case "https" => true
       case "http" => false
       case other =>
         throw new IllegalArgumentException(s"$other is not a supported protocol. Only HTTPS and HTTP are supported.")
     }
   }
-
-  /** @return The defined port or default port for given protocol. */
-  def effectivePort(url: URL): Int = if (url.getPort == -1) url.getDefaultPort else url.getPort
 }
 
 object SessionActor {

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/client/Session.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.headers.{Authorization, HttpCredentials}
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.{Materializer, WatchedActorTerminatedException}
 import akka.stream.scaladsl.{Flow, FlowWithContext}
 import akka.util.Timeout

--- a/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
+++ b/mesos-client/src/main/scala/com/mesosphere/mesos/conf/MesosClientSettings.scala
@@ -23,6 +23,7 @@ class MesosClientSettings private (
     new MesosClientSettings(masters, maxRedirects, idleTimeout, sourceBufferSize, callTimeout)
 
   def withMasters(urls: Iterable[URL]): MesosClientSettings = copy(masters = urls.toSeq)
+  def withMasters(urls: URL*): MesosClientSettings = copy(masters = urls)
   def withMasters(urls: java.lang.Iterable[URL]): MesosClientSettings = withMasters(urls.asScala)
 
   def withMaxRedirects(maxRedirects: Int): MesosClientSettings = copy(maxRedirects = maxRedirects)

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
@@ -1,5 +1,4 @@
 package com.mesosphere.mesos.client
-import java.net.URL
 
 import akka.http.scaladsl.model.Uri
 import akka.stream.KillSwitches

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientImplTest.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.mesos.client
 import java.net.URL
 
+import akka.http.scaladsl.model.Uri
 import akka.stream.KillSwitches
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
@@ -20,7 +21,7 @@ class MesosClientImplTest extends AkkaUnitTest {
       val frameworkId = FrameworkID.newBuilder().setValue("framework").build()
       val subscribedEvent = Event.Subscribed.newBuilder().setMasterInfo(masterInfo).setFrameworkId(frameworkId).build()
       val sharedKillSwitch = KillSwitches.shared("mesos-client-killswitch")
-      val session = Session(new URL("http://localhost"), "stream-id")
+      val session = Session(Uri("http://localhost"), "stream-id")
 
       a[IllegalArgumentException] should be thrownBy {
         new MesosClientImpl(null, sharedKillSwitch, subscribedEvent, session, Source.empty)
@@ -32,7 +33,7 @@ class MesosClientImplTest extends AkkaUnitTest {
       val frameworkId = FrameworkID.newBuilder().setValue("framework").build()
       val subscribedEvent = Event.Subscribed.newBuilder().setMasterInfo(masterInfo).setFrameworkId(frameworkId).build()
       val sharedKillSwitch = KillSwitches.shared("mesos-client-killswitch")
-      val session = new Session(new URL("http://localhost"), "stream-id")
+      val session = new Session(Uri("http://localhost"), "stream-id")
 
       noException should be thrownBy {
         new MesosClientImpl(null, sharedKillSwitch, subscribedEvent, session, Source.empty)

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientIntegrationTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/MesosClientIntegrationTest.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.mesosphere.mesos.conf.MesosClientSettings
 import com.mesosphere.utils.AkkaUnitTest
-import com.mesosphere.utils.mesos.MesosClusterTest
+import com.mesosphere.utils.mesos.{MesosClusterTest, MesosConfig}
 import org.apache.mesos.v1.Protos.{Filters, FrameworkID, FrameworkInfo}
 import org.apache.mesos.v1.scheduler.Protos.Event
 
@@ -17,17 +17,19 @@ import scala.concurrent.Future
 
 class MesosClientIntegrationTest extends AkkaUnitTest with MesosClusterTest {
 
-  "Mesos client should successfully subscribe to mesos without framework Id" in withFixture() { f =>
+  override lazy val mesosConfig = MesosConfig(numMasters = 3)
+
+  "Mesos client should successfully subscribe to Mesos without framework Id" in withFixture() { f =>
     Then("a framework successfully subscribes without a framework Id")
     f.client.frameworkId.getValue shouldNot be(empty)
 
     And("connection context should be initialized")
-    f.client.session.url.getHost shouldBe f.mesosHost
+    f.client.session.baseUri.toString() shouldBe f.mesosHost.toString
     f.client.session.streamId.length should be > 1
     f.client.frameworkId.getValue.length should be > 1
   }
 
-  "Mesos client should successfully subscribe to mesos with framework Id" in {
+  "Mesos client should successfully subscribe to Mesos with framework Id" in {
     val frameworkID = FrameworkID.newBuilder.setValue(UUID.randomUUID().toString)
 
     When("a framework subscribes with a framework Id")
@@ -43,6 +45,21 @@ class MesosClientIntegrationTest extends AkkaUnitTest with MesosClusterTest {
 
     Then("a heartbeat event should arrive")
     heartbeat shouldNot be(empty)
+  }
+
+  "Mesos client should follow redirect" in {
+    Given("client settings with non-leader URL")
+    val nonLeader = mesosCluster.masters.find(_.port != mesosFacade.url.getPort).value.host()
+    val settings = MesosClientSettings.load().withMasters(nonLeader)
+
+    When(s"we connect to $nonLeader")
+    val f = new Fixture(settings = settings)
+
+    Then("a new framework should register")
+    // TODO: withFixture
+
+    And("a heartbeat should arrive")
+    f.pullUntil(_.getType == Event.Type.HEARTBEAT) shouldNot be(empty)
   }
 
   "Mesos client should successfully receive offers" in withFixture() { f =>
@@ -88,7 +105,9 @@ class MesosClientIntegrationTest extends AkkaUnitTest with MesosClusterTest {
     }
   }
 
-  class Fixture(existingFrameworkId: Option[FrameworkID.Builder] = None) {
+  class Fixture(
+      existingFrameworkId: Option[FrameworkID.Builder] = None,
+      val settings: MesosClientSettings = MesosClientSettings.load().withMasters(mesosFacade.url)) {
     implicit val system: ActorSystem = ActorSystem()
     implicit val materializer: ActorMaterializer = ActorMaterializer()
 
@@ -98,14 +117,12 @@ class MesosClientIntegrationTest extends AkkaUnitTest with MesosClusterTest {
       .setName("Mesos Client Integration Tests")
       .setId(existingFrameworkId.getOrElse(FrameworkID.newBuilder.setValue(UUID.randomUUID().toString)))
       .addRoles("test")
-      .setFailoverTimeout(0.0f)
+      .setFailoverTimeout(30.0f)
       .addCapabilities(FrameworkInfo.Capability.newBuilder().setType(FrameworkInfo.Capability.Type.MULTI_ROLE))
       .build()
 
     lazy val mesosHost = mesosFacade.url.getHost
     lazy val mesosPort = mesosFacade.url.getPort
-
-    val settings = MesosClientSettings.load().withMasters(Seq(mesosFacade.url))
 
     val client = MesosClient(settings, frameworkInfo).runWith(Sink.head).futureValue
 
@@ -131,4 +148,5 @@ class MesosClientIntegrationTest extends AkkaUnitTest with MesosClusterTest {
           pullUntil(predicate)
       }
   }
+
 }

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
@@ -20,7 +20,7 @@ class SessionActorTest extends AkkaUnitTest {
 
       Given("A SessionActor and an HTTP response")
       val sessionActor =
-        system.actorOf(SessionActor.props(BasicAuthenticationProvider("user", "password"), f.requestFactory))
+        system.actorOf(SessionActor.props(Some(BasicAuthenticationProvider("user", "password")), f.requestFactory))
       val originalSender = TestProbe()
       val httpResponse = HttpResponse(entity = HttpEntity("hello"))
 
@@ -37,7 +37,7 @@ class SessionActorTest extends AkkaUnitTest {
       Given("A simple Mesos API stub and a SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
-        system.actorOf(SessionActor.props(credentialsProvider, mesos.createRequest))
+        system.actorOf(SessionActor.props(Some(credentialsProvider), mesos.createRequest))
 
       When("we make a call through the session actor")
       val response = (sessionActor ? Array.empty[Byte]).futureValue.asInstanceOf[HttpResponse]
@@ -60,7 +60,7 @@ class SessionActorTest extends AkkaUnitTest {
       Given("A SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
-        system.actorOf(SessionActor.props(credentialsProvider, mesos.createRequest))
+        system.actorOf(SessionActor.props(Some(credentialsProvider), mesos.createRequest))
 
       When("we make a call through the session actor")
       val response = (sessionActor ? Array.empty[Byte]).futureValue.asInstanceOf[HttpResponse]

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
@@ -2,6 +2,7 @@ package com.mesosphere.mesos.client
 
 import akka.pattern.ask
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -16,11 +17,11 @@ class SessionActorTest extends AkkaUnitTest {
 
   "The Session Actor" should {
     "replied with a response to the original sender" in {
-      val f = new Fixture
-
       Given("A SessionActor and an HTTP response")
       val sessionActor =
-        system.actorOf(SessionActor.props(Some(BasicAuthenticationProvider("user", "password")), f.requestFactory))
+        system.actorOf(
+          SessionActor
+            .props(Some(BasicAuthenticationProvider("user", "password")), "some-strean-id", Uri("http://example.com")))
       val originalSender = TestProbe()
       val httpResponse = HttpResponse(entity = HttpEntity("hello"))
 
@@ -37,7 +38,7 @@ class SessionActorTest extends AkkaUnitTest {
       Given("A simple Mesos API stub and a SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
-        system.actorOf(SessionActor.props(Some(credentialsProvider), mesos.createRequest))
+        system.actorOf(SessionActor.props(Some(credentialsProvider), "some-stream-id", mesos.uri))
 
       When("we make a call through the session actor")
       val response = (sessionActor ? Array.empty[Byte]).futureValue.asInstanceOf[HttpResponse]
@@ -60,7 +61,7 @@ class SessionActorTest extends AkkaUnitTest {
       Given("A SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
-        system.actorOf(SessionActor.props(Some(credentialsProvider), mesos.createRequest))
+        system.actorOf(SessionActor.props(Some(credentialsProvider), "some-stream-id", mesos.uri))
 
       When("we make a call through the session actor")
       val response = (sessionActor ? Array.empty[Byte]).futureValue.asInstanceOf[HttpResponse]
@@ -74,11 +75,23 @@ class SessionActorTest extends AkkaUnitTest {
       And("the session token was fetched twice")
       credentialsProvider.calls should be(2)
     }
-  }
 
-  class Fixture() {
+    "follow a redirect" in withMesosStub(StatusCodes.OK) { mesos =>
+      implicit val timeout = Timeout(2.seconds)
 
-    def requestFactory(body: Array[Byte], credentials: Option[HttpCredentials]): HttpRequest = ???
+      Given("A SessionActor instance")
+      val sessionActor =
+        system.actorOf(SessionActor.props(None, "some-stream-id", mesos.uri.withPath(Path("/redirected"))))
+
+      When("we make a call through the session actor")
+      val response = (sessionActor ? Array.empty[Byte]).futureValue.asInstanceOf[HttpResponse]
+
+      Then("we receive an HTTP 200")
+      response.status should be(StatusCodes.OK)
+
+      And("/mesos was called once: the redirected call")
+      Unmarshal(response.entity).to[String].futureValue.toInt should be(1)
+    }
   }
 
   /**
@@ -124,23 +137,25 @@ class SessionActorTest extends AkkaUnitTest {
     @volatile var calls: Int = 0
 
     val route =
-      path("mesos") {
-        post {
-          calls += 1
-          responseCodes match {
-            case head :: tail =>
-              responseCodes = tail
-              complete(head -> calls.toString)
-            case Nil =>
-              complete(StatusCodes.NotImplemented -> "Provided response codes exhausted.")
+      post {
+        concat(
+          path("mesos") {
+            calls += 1
+            responseCodes match {
+              case head :: tail =>
+                responseCodes = tail
+                complete(head -> calls.toString)
+              case Nil =>
+                complete(StatusCodes.NotImplemented -> "Provided response codes exhausted.")
+            }
+          },
+          path("redirected") {
+            redirect("/mesos", StatusCodes.TemporaryRedirect)
           }
-        }
+        )
       }
 
     val binding = Http().bindAndHandle(route, "localhost", 0).futureValue
     val uri = Uri(s"http://localhost:${binding.localAddress.getPort}/mesos")
-
-    def createRequest(body: Array[Byte], credentials: Option[HttpCredentials]): HttpRequest =
-      HttpRequest(HttpMethods.POST, uri = uri)
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 
 // Documentation
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -211,7 +211,7 @@ case class MesosCluster(
   def failover(): URL = {
     require(config.numMasters > 1, s"The number of masters ${config.numMasters} is not bigger than 1.")
 
-    val leaderPort = new URL(masterUrl).getPort
+    val leaderPort = waitForLeader().getPort
     val oldLeader = masters
       .find(_.port == leaderPort)
       .getOrElse(

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -220,7 +220,7 @@ case class MesosCluster(
     eventually(timeout(waitForMesosTimeout), interval(1.seconds)) {
       val possibleNewLeader = waitForLeader();
       assert(leaderPort != possibleNewLeader.getPort, "Leader did not change.")
-      logger.info(s"Changed leader from $oldLeader to ${possibleNewLeader.getPort}.")
+      logger.info(s"Changed leader from $leaderPort to ${possibleNewLeader.getPort}.")
       possibleNewLeader
     }
   }

--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -220,6 +220,7 @@ case class MesosCluster(
     eventually(timeout(waitForMesosTimeout), interval(1.seconds)) {
       val possibleNewLeader = waitForLeader();
       assert(leaderPort != possibleNewLeader.getPort, "Leader did not change.")
+      logger.info(s"Changed leader from $oldLeader to ${possibleNewLeader.getPort}.")
       possibleNewLeader
     }
   }


### PR DESCRIPTION
Summary:
The redirect implementation would not resolve the location correctly. This patch moves the
redirect handling into the `connectionSource` and uses `flatMapConcat` instead of a
recover and exception.

The `SessionActor` follows redirects as well.

Also
* Add cluster restart and failover to test fixtures.
* The call flow was simplified to always use the session actor.