### PR TITLE
Replace ask with sending request to make Mesos calls.

### DIFF
--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
@@ -31,8 +31,6 @@ class SessionActorTest extends AkkaUnitTest {
     }
 
     "make a simple call to Mesos" in withMesosStub(StatusCodes.OK) { mesos =>
-      implicit val timeout = Timeout(2.seconds)
-
       Given("A simple Mesos API stub and a SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
@@ -56,8 +54,6 @@ class SessionActorTest extends AkkaUnitTest {
     "refresh the session token when the first call response is an HTTP 401" in withMesosStub(
       StatusCodes.Unauthorized,
       StatusCodes.OK) { mesos =>
-      implicit val timeout = Timeout(2.seconds)
-
       Given("A SessionActor instance")
       val credentialsProvider = new CountingCredentialsProvider()
       val sessionActor =
@@ -79,8 +75,6 @@ class SessionActorTest extends AkkaUnitTest {
     }
 
     "follow a redirect" in withMesosStub(StatusCodes.OK) { mesos =>
-      implicit val timeout = Timeout(2.seconds)
-
       Given("A SessionActor instance")
       val sessionActor =
         system.actorOf(SessionActor.props(None, "some-stream-id", mesos.uri.withPath(Path("/redirected"))))

--- a/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
+++ b/mesos-client/src/test/scala/com/mesosphere/mesos/client/SessionActorTest.scala
@@ -5,11 +5,9 @@ import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.util.Timeout
 import com.mesosphere.utils.AkkaUnitTest
 
 import scala.concurrent.{Future, Promise}
-import scala.concurrent.duration._
 
 class SessionActorTest extends AkkaUnitTest {
 


### PR DESCRIPTION
Summary:
The last MWT showed `AskTimeoutExceptions` when Mesos would not respond in time during
a Mesos master failover. This timeout was the result of an HTTP request timing out and is hard
to debug. It also leaves dead letters.

This change sends a promise instead. The promise is completed with the HTTP request result
which can include a timeout. It should ease debugging.