### PR TITLE
Changed the credential format in MesosTest from plaintext to JSON.

### DIFF
--- a/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
+++ b/test-utils/src/main/scala/com/mesosphere/utils/mesos/MesosTest.scala
@@ -379,7 +379,16 @@ case class MesosCluster(
       file.getAbsolutePath
     }
 
-    val credentialsPath = write(mesosWorkDir, fileName = "credentials", content = "principal1 secret1")
+    val credentialsPath = write(
+      mesosWorkDir,
+      fileName = "credentials",
+      content = """
+        |{
+        |  "credentials" : [{ "principal": "principal1", "secret": "secret1" }]
+        |}
+      """.stripMargin
+    )
+
     val aclsPath = write(
       mesosWorkDir,
       fileName = "acls.json",


### PR DESCRIPTION
This makes it possible to run tests againts Mesos 1.11.0+ which
has dropped the plaintext credential format that has been deprecated
since Mesos 0.29.0 (see https://reviews.apache.org/r/72600)